### PR TITLE
Added slug-based routing for the individual project pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import AboutPage from "./pages/AboutPage";
 import ProjectsPage from "./pages/ProjectsPage";
 import StudentsPage from "./pages/StudentsPage";
 import NonprofitsPage from "./pages/NonprofitsPage";
+import IndividualProject from "./pages/IndividualProject";
 import Footer from "./components/footer/Footer";
 import ScrollToHashElement from "./components/shared/ScrollToHash";
 
@@ -22,6 +23,7 @@ function App() {
         <Route path="/projectspage" element={<ProjectsPage />} />
         <Route path="/students" element={<StudentsPage />} />
         <Route path="/nonprofits" element={<NonprofitsPage />} />
+        <Route path="/projects/:slug" element={<IndividualProject />} />
       </Routes>
       </main>
       <Footer></Footer>

--- a/src/components/layout/BlankPage.jsx
+++ b/src/components/layout/BlankPage.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import PageContainer from "./PageContainer";
+
+export default function BlankPage({ title }) {
+  return (
+    <PageContainer className="py-16">
+      <h1 className="text-3xl font-semibold">{title}</h1>
+      <p className="mt-4 text-gray-600">
+        Blank page placeholder for the website revamp.
+      </p>
+    </PageContainer>
+  );
+}

--- a/src/components/layout/PageContainer.jsx
+++ b/src/components/layout/PageContainer.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function PageContainer({ children, className = "" }) {
+  return (
+    <div className={`w-full px-6 md:px-10 xl:px-36 ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/constants/projects.js
+++ b/src/constants/projects.js
@@ -20,6 +20,7 @@ import { ReelYouth } from "./Team/ReelYouth";
 export const Projects = [
   {
     name: "Mosaic",
+    slug: "mosaic",
     description: "Aiding New Comers to Canada",
     date: "November 2023 - Current",
     tags: ["Immigration", "AI / Bot"],
@@ -34,6 +35,7 @@ export const Projects = [
   },
   {
     name: "Pedals",
+    slug: "pedals",
     description: "Empowering Communities Through Bicycles",
     date: "January 2024 - Current",
     tags: ["Community", "Admin"],
@@ -48,6 +50,7 @@ export const Projects = [
   },
   {
     name: "Blueprint Website",
+    slug: "blueprint-website",
     description: "Taking SFU Blueprint LIVE",
     date: "September 2023 - December 2023",
     tags: ["Innovation", "Website"],
@@ -61,6 +64,7 @@ export const Projects = [
   },
   {
     name: "Reel Youth",
+    slug: "reel-youth",
     description: "Helping Reel Youth build website",
     date: "August 2024 - Current",
     tags: ["Community", "Website"],

--- a/src/pages/IndividualProject.jsx
+++ b/src/pages/IndividualProject.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import PageContainer from "../components/layout/PageContainer";
+import { Projects } from "../constants/projects"; // adjust if your path/file name differs
+
+export default function IndividualProject() {
+  const { slug } = useParams();
+
+  const project = Projects.find((p) => p.slug === slug);
+
+  if (!project) {
+    return (
+      <PageContainer className="py-16">
+        <h1 className="text-2xl font-semibold">Project not found</h1>
+        <p className="mt-4 text-gray-600">
+          Check the URL or pick a project from the Projects page.
+        </p>
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer className="py-16">
+      <h1 className="text-3xl font-semibold">{project.name}</h1>
+      <p className="mt-4 text-gray-600">{project.description}</p>
+    </PageContainer>
+  );
+}


### PR DESCRIPTION
## What this PR does
- Introduces slug-based routing for individual project pages
- Adds a reusable PageContainer layout wrapper
- Implements a data-driven IndividualProject page using URL params

## Why this change
This sets up scalable routing for project detail pages so future projects
can be added without creating new routes or hardcoded pages.