### PR TITLE
Ignore env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
## What this PR does

- Adds `.env` to `.gitignore` to prevent environment files from being committed

## Why this change

A `.env` file was accidentally committed earlier and merged into `main`.  
This PR prevents similar issues going forward by ensuring environment files are ignored by Git.

## Notes

- This change is preventative and does not modify existing history
- Any affected secrets have been rotated / can be rotated as needed