### PR TITLE
Add Reusable CalloutCard Component

### DIFF
--- a/src/components/shared/CalloutCard.tsx
+++ b/src/components/shared/CalloutCard.tsx
@@ -6,6 +6,16 @@ export type CalloutCardProps = {
   stripeColor?: string;
   variant?: "default" | "white" | "dark";
   icon?: React.ReactNode;
+  /** Show 1px border; when undefined, border is shown only for variant "white" */
+  showBorder?: boolean;
+  /** Border color when showBorder is true; defaults to stripeColor */
+  borderColor?: string;
+  /** Override card background (e.g. "#FFFFFF", "#353535"); when set, variant background is ignored */
+  backgroundColor?: string;
+  /** Override title text color (useful with custom backgroundColor) */
+  titleColor?: string;
+  /** Override body text color (useful with custom backgroundColor) */
+  bodyColor?: string;
 };
 
 const STRIPE_WIDTH_PX = 8;
@@ -17,32 +27,48 @@ export default function CalloutCard({
   stripeColor = defaultStripeColor,
   variant = "default",
   icon,
+  showBorder,
+  borderColor,
+  backgroundColor,
+  titleColor,
+  bodyColor,
 }: CalloutCardProps) {
   const isDark = variant === "dark";
-  const bgClass =
-    variant === "white"
+  const isWhite = variant === "white";
+
+  const defaultBgClass =
+    isWhite
       ? "bg-white"
       : isDark
         ? "bg-blueprint-neutral-dark"
         : "bg-blueprint-gray-light";
+  const useCustomBg = backgroundColor != null;
+  const bgClass = useCustomBg ? "" : defaultBgClass;
 
-  const titleClass = isDark
+  const defaultTitleClass = isDark
     ? "text-blueprint-neutral-muted font-bold text-[24px] uppercase tracking-tight"
     : "text-blueprint-black font-bold text-[24px] uppercase tracking-tight";
-  const bodyClass = isDark
+  const defaultBodyClass = isDark
     ? "text-blueprint-neutral-muted text-[16px] font-normal leading-relaxed m-0 whitespace-pre-line"
     : "text-blueprint-black text-[16px] font-normal leading-relaxed m-0";
 
-  const isWhite = variant === "white";
+  const effectiveShowBorder = showBorder ?? isWhite;
+  const effectiveBorderColor = borderColor ?? stripeColor;
+
+  const articleStyle: React.CSSProperties = {
+    borderRadius: "3px 10px 10px 3px",
+    ...(useCustomBg && { backgroundColor }),
+    ...(effectiveShowBorder && {
+      borderWidth: "1px",
+      borderStyle: "solid",
+      borderColor: effectiveBorderColor,
+    }),
+  };
 
   return (
     <article
-      className={`w-full min-w-0 flex overflow-hidden font-poppins ${bgClass} ${isWhite ? "border" : ""}`}
-      style={
-        isWhite
-          ? { borderWidth: "1px", borderStyle: "solid", borderColor: stripeColor, borderRadius: "3px 10px 10px 3px" }
-          : { borderRadius: "3px 10px 10px 3px" }
-      }
+      className={`w-full min-w-0 flex overflow-hidden font-poppins ${bgClass}`}
+      style={articleStyle}
       aria-labelledby="callout-card-title"
     >
       {/* Vertical stripe (left) */}
@@ -58,7 +84,11 @@ export default function CalloutCard({
       {/* Content: padding 36 top, 24 right, 48 bottom, 48 left (spec); 12px gap */}
       <div className="flex flex-col flex-1 min-w-0 pt-6 pr-4 pb-8 pl-8 md:pt-[36px] md:pr-[24px] md:pb-[48px] md:pl-[48px] gap-3">
         <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-          <h2 id="callout-card-title" className={titleClass}>
+          <h2
+            id="callout-card-title"
+            className={titleColor == null ? defaultTitleClass : "font-bold text-[24px] uppercase tracking-tight"}
+            style={titleColor != null ? { color: titleColor } : undefined}
+          >
             {title}
           </h2>
           {icon != null && (
@@ -67,7 +97,12 @@ export default function CalloutCard({
             </span>
           )}
         </div>
-        <p className={bodyClass}>{body}</p>
+        <p
+          className={bodyColor == null ? defaultBodyClass : "text-[16px] font-normal leading-relaxed m-0 whitespace-pre-line"}
+          style={bodyColor != null ? { color: bodyColor } : undefined}
+        >
+          {body}
+        </p>
       </div>
     </article>
   );


### PR DESCRIPTION
## Summary
Adds a reusable `CalloutCard` component that matches the approved wireframes, supports three variants, and allows full control over border, background, and text colors.

---

## Changes

### New
- `src/components/shared/CalloutCard.tsx`

---

## Core Props

- `title`
- `body`
- `stripeColor?`
- `variant?` (`"default" | "white" | "dark"`)
- `icon?` (`ReactNode`)

---

## Customization Props

- `showBorder?`
  - `true` → 1px border
  - `false` → no border
  - Omitted → border only when `variant="white"`

- `borderColor?`
  - Border color when `showBorder` is `true`
  - Defaults to `stripeColor`

- `backgroundColor?`
  - Overrides card background (e.g. `"#353535"`)
  - Ignores variant background when set

- `titleColor?`, `bodyColor?`
  - Override title/body text color
  - Useful for custom backgrounds

---

## Variants

- **default**
  - Light grey background (`bg-blueprint-gray-light`)
  - Border optional via `showBorder`

- **white**
  - White background
  - Border optional (default: on)
  - Can be disabled with `showBorder={false}`

- **dark**
  - Dark background
  - Light muted text for dark sections

---

## Layout & Styling

- Left vertical stripe (8px wide, color from `stripeColor`)
- Border radius:
  - 3px top-left
  - 10px top-right
  - 10px bottom-right
  - 3px bottom-left
- Padding:
  - Desktop: 36px top, 24px right, 48px bottom, 48px left
  - Reduced on mobile
- Typography:
  - Title: 24px, bold, uppercase
  - Body: 16px, normal weight
- Optional icon displayed beside the title
- Border and background fully configurable

---

## Responsive

- Single-column on small screens
- No overflow
- Padding scales down on mobile

---

## Verification

- `CalloutCard` is self-contained and only used where imported
- TypeScript types and Tailwind usage are consistent with the rest of the app
- No changes to routes or build configuration
- No console errors or warnings

## Screenshots


Desktop  View:
<img width="917" height="799" alt="image" src="https://github.com/user-attachments/assets/1fbb23f4-53c0-4f70-aeb8-fe961c18ff9c" />

Mobile View:
<img width="860" height="775" alt="image" src="https://github.com/user-attachments/assets/1f1acc5e-4ebb-4b5b-b988-9cd8ef8d2f66" />


Closes #46 

