### PR TITLE
fix: NavigationTabs underline matches text length

### DIFF
--- a/src/components/shared/NavigationTabs.tsx
+++ b/src/components/shared/NavigationTabs.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 
 export interface NavigationTabsProps {
@@ -6,13 +6,35 @@ export interface NavigationTabsProps {
   activeHref?: string;
 }
 
+const UNDERLINE_EXTRA_PX = 8;
+
 export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps) {
+  const textRefs = useRef<(HTMLSpanElement | null)[]>([]);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [underlineLeft, setUnderlineLeft] = useState(0);
+  const [underlineWidth, setUnderlineWidth] = useState(0);
+
+  const activeIndex = activeHref != null ? tabs.findIndex((t) => t.href === activeHref) : -1;
+  const effectiveIndex = activeIndex >= 0 ? activeIndex : 0;
+
+  useEffect(() => {
+    const textEl = textRefs.current[effectiveIndex];
+    const container = containerRef.current;
+    if (textEl && container) {
+      const containerRect = container.getBoundingClientRect();
+      const textRect = textEl.getBoundingClientRect();
+      setUnderlineLeft(textRect.left - containerRect.left - UNDERLINE_EXTRA_PX);
+      setUnderlineWidth(textRect.width + UNDERLINE_EXTRA_PX * 2);
+    }
+  }, [effectiveIndex, tabs]);
+
   return (
     <nav className="w-full font-poppins" aria-label="Section navigation">
       <div
-        className="flex flex-nowrap gap-x-6 overflow-x-auto border-b border-blueprint-neutral-mutedAlt [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+        ref={containerRef}
+        className="relative flex flex-nowrap gap-x-6 overflow-x-auto border-b border-blueprint-neutral-mutedAlt [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
       >
-        {tabs.map((tab) => {
+        {tabs.map((tab, i) => {
           const isActive = activeHref != null && tab.href === activeHref;
           return (
             <Link
@@ -20,14 +42,15 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
               to={tab.href}
               className={`group relative block shrink-0 py-3 px-4 text-sm leading-[100%] tracking-normal whitespace-nowrap transition-colors duration-150 ${
                 isActive ? "text-blueprint-linkHover" : "text-blueprint-neutral-dark"
-              }               ${
-                isActive
-                  ? "-mb-px after:content-[''] after:absolute after:left-0 after:right-0 after:bottom-[-1px] after:h-[6px] after:bg-blueprint-linkHover after:rounded-t-full after:shadow-[0_2px_4px_rgba(0,0,0,0.1)]"
-                  : ""
               }`}
               aria-current={isActive ? "page" : undefined}
             >
-              <span className="relative inline-block">
+              <span
+                className="relative inline-block"
+                ref={(el) => {
+                  textRefs.current[i] = el;
+                }}
+              >
                 <span className="font-semibold invisible select-none" aria-hidden>
                   {tab.label}
                 </span>
@@ -40,6 +63,13 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
             </Link>
           );
         })}
+        {activeIndex >= 0 && (
+          <span
+            className="absolute left-0 bottom-0 -mb-px h-[4px] bg-blueprint-linkHover rounded-t-full shadow-[0_2px_4px_rgba(0,0,0,0.1)] transition-all duration-150 ease-out"
+            style={{ left: underlineLeft, width: underlineWidth }}
+            aria-hidden
+          />
+        )}
       </div>
     </nav>
   );


### PR DESCRIPTION
## Summary
- NavigationTabs underline width and position now match the active tab’s text (via refs + getBoundingClientRect).
- Underline extends 8px past the text on each side and is 4px tall.

## Summary
- NavigationTabs underline width and position now match the active tab’s text (via refs + getBoundingClientRect).
- Underline extends 8px past the text on each side and is 4px tall.

## How to use

**Props**
- `tabs`: `{ label: string; href: string }[]` — tab label and link (path or path + hash).
- `activeHref`: `string` (optional) — current location so the correct tab is active (e.g. `pathname` or `pathname + hash`).

**Example (single page with hash sections)**

```tsx
import { useLocation } from "react-router-dom";
import NavigationTabs from "../components/shared/NavigationTabs";

const tabs = [
  { label: "MEET BLUEPRINT", href: "/about" },
  { label: "APPLY", href: "/about#apply" },
  { label: "INTERVIEW", href: "/about#interview" },
  { label: "FINAL DECISION", href: "/about#final-decision" },
  { label: "ONBOARDING", href: "/about#onboarding" },
];

function AboutPage() {
  const { pathname, hash } = useLocation();
  const activeHref = pathname + (hash || "");

  return (
    <div>
      <h1>About Us</h1>
      <NavigationTabs tabs={tabs} activeHref={activeHref} />
      {/* section content */}
    </div>
  );
}
```
**Example (separate routes)**
```tsx
const tabs = [
  { label: "Overview", href: "/about" },
  { label: "Team", href: "/about/team" },
  { label: "Alumni", href: "/about/alumni" },
];

function Layout() {
  const { pathname } = useLocation();
  return <NavigationTabs tabs={tabs} activeHref={pathname} />;
}
```

## Screenshots:
- Desktop (APPLY Tab being hovered):
<img width="975" height="294" alt="image" src="https://github.com/user-attachments/assets/92c73d3d-0fdb-479a-bc77-394ca43b9d68" />
<img width="908" height="160" alt="image" src="https://github.com/user-attachments/assets/74ae4cbc-8265-4c25-b150-831e51417b4d" />

- Mobile:
<img width="395" height="768" alt="image" src="https://github.com/user-attachments/assets/40b7af6f-5e9e-4ad5-8247-7b7fc1f36453" />

Closes #31 