### PR TITLE
Filters light variant, Projects page typography, Blueprint tokens

### DIFF
--- a/src/components/shared/Filters.tsx
+++ b/src/components/shared/Filters.tsx
@@ -1,29 +1,79 @@
-// Implement the Filters component to match the approved wireframes. 
-// This is a reusable UI element for displaying a vertical stack of filter “pills” (outlined and filled states).
+// Filters component — dark-context pills (wireframes) + light-context pills (white-background pages).
 
-const Filters = ({state,title}: {state: 'outlined' | 'filled', title: string}) => {
+import type { ButtonHTMLAttributes } from "react";
 
-    if (state === 'outlined') {
-        return(
-            // Outlined State
-            <button
-                type="button"
-                className="w-fit text-white text-sm font-medium font-['Poppins'] uppercase py-3 px-[18px]
-                md:py-[10px] md:px-[30px] md:rounded-[10px] rounded-[5px] border border-blueprint-white bg-blueprint-white/20"
-            >
-                {title}
-            </button>
-        )
-    } else {
-        return(
-            // Filled State
-            <button className="w-fit text-blueprint-neutral-dark text-sm font-medium font-['Poppins'] uppercase 
-            py-3 px-[18px] md:py-[10px] md:px-[30px] md:rounded-[10px] rounded-[5px] bg-blueprint-white">
-                    {title}
-                </button>
-      
-        )
-    }
-};
+/** Original wireframe variant: translucent or solid white on dark/diagonal backgrounds */
+export type FiltersDarkProps = {
+  title: string;
+  state: "outlined" | "filled";
+  variant?: "dark";
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type" | "children">;
+
+/** White-background pages: gray default pill + light-blue selected pill */
+export type FiltersLightProps = {
+  title: string;
+  state: "default" | "selected";
+  variant: "light";
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "type" | "children">;
+
+export type FiltersProps = FiltersDarkProps | FiltersLightProps;
+
+const baseTypography =
+  "font-poppins text-center font-semibold uppercase text-xs leading-[125%]";
+
+/**
+ * Shared shell for both variants so dark and light pills match Figma (same size, radius, gap, padding).
+ * Previously dark omitted `min-h-[42px]` below desktop, so it looked shorter than light on tablet/mobile.
+ */
+const pillLayout =
+  "inline-flex min-h-[42px] justify-center items-center gap-[10px] rounded-[10px] px-[18px] py-3 desktop:h-[42px] desktop:min-h-0 desktop:px-[30px] desktop:py-[10px]";
+
+function Filters(props: FiltersProps) {
+  if (props.variant === "light") {
+    const { title, state, className, variant: _v, ...rest } = props;
+    const isSelected = state === "selected";
+
+    return (
+      <button
+        type="button"
+        className={[
+          pillLayout,
+          baseTypography,
+          "border",
+          isSelected
+            ? "border-blueprint-accent-lightBlue bg-blueprint-accent-veryLightBlue text-blueprint-black"
+            : "border-blueprint-filterOnWhite-border bg-blueprint-filterOnWhite-bgDefault text-blueprint-black",
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        {...rest}
+      >
+        {title}
+      </button>
+    );
+  }
+
+  const { title, state, className, ...rest } = props;
+
+  return (
+    <button
+      type="button"
+      className={[
+        pillLayout,
+        baseTypography,
+        state === "outlined"
+          ? "border border-blueprint-white bg-blueprint-white/20 text-blueprint-white"
+          : "border border-transparent bg-blueprint-white text-blueprint-neutral-dark",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      {...rest}
+    >
+      {title}
+    </button>
+  );
+}
 
 export default Filters;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,45 +1,58 @@
-import React from "react";
+import React, { useState } from "react";
 import PageContainer from "../components/layout/PageContainer";
-import ProjectCard  from "../components/projects-page/ProjectProjectCard";
+import ProjectCard from "../components/projects-page/ProjectProjectCard";
 import Filters from "../components/shared/Filters";
 
 const ProjectsPage = () => {
-  const filterNames = ["Web App", "Website", "Plugin"];
+  const filterNames = ["Web-App", "Website", "Plug-In"] as const;
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
   return (
-    <PageContainer className="bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat bg-blueprint-gray-light 
+    <PageContainer
+      className="bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat bg-blueprint-gray-light 
                               min-[1280px]:bg-[calc(100%+585px)_-500px]
                               max-[1279px]:bg-[calc(100%+689px)_-500px]
-                              max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_-132px]">
-
+                              max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_-132px]"
+    >
       {/* Main Container Flex Column */}
       <div className="flex flex-col gap-4 items-center justify-center">
-          {/* Title */}
-          <h1>our projects</h1>
-          
-          {/* Filters Flex Row (Web app, Website, Plugin)*/}
+        {/* Title — desktop/heading/m-reg */}
+        <h1 className="text-center font-poppins text-blueprint-heading text-heading-m-reg-mobile desktop:text-heading-m-reg">
+          our projects
+        </h1>
+
+        {/* Filters — light variant for light gray / patterned background (Figma) */}
+        <div
+          className="flex flex-row flex-wrap gap-[10px] items-center justify-center"
+          role="group"
+          aria-label="Project type filters"
+        >
+          {filterNames.map((name, index) => (
+            <Filters
+              key={name}
+              variant="light"
+              state={selectedIndex === index ? "selected" : "default"}
+              title={name}
+              onClick={() => setSelectedIndex(index)}
+              aria-pressed={selectedIndex === index}
+            />
+          ))}
+        </div>
+
+        {/* Projects Flex Row  Max 2 cards per row*/}
+        <div className="flex flex-row gap-4 items-center justify-center">
           <div className="flex flex-row gap-4 items-center justify-center">
-            {filterNames.map((name) => (
-              <Filters state="filled" title={name} />
-            ))}
+            <ProjectCard />
           </div>
-          
-          {/* Projects Flex Row  Max 2 cards per row*/}
-          <div className="flex flex-row gap-4 items-center justify-center">
-              <div className="flex flex-row gap-4 items-center justify-center">
-                <ProjectCard />
-              </div>
-              {/* 
+          {/*
               <div className="flex flex-col gap-4 items-center justify-center">
                 <ProjectCard />
                 <ProjectCard />
               </div> */}
-          </div>
-
+        </div>
       </div>
       {/* CTA Button - Absolute Positioned Centered */}
-      <div>
-
-      </div>
+      <div />
     </PageContainer>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,7 +30,11 @@ module.exports = {
             mediumBlue: "#5387E3",
             purple: "#D2A6FB",
           },
-          orange: "#F49F00",
+          // Filter pills on white/light surfaces (Figma: default border + translucent gray fill)
+          filterOnWhite: {
+            border: "#CACACA",
+            bgDefault: "rgba(213, 213, 213, 0.30)",
+          },
           // Neutrals / grey scale (palette: bp-light-grey, bp-grey, bp-dark-grey, bp-lightest-grey)
           gray: {
             dark: "#B8B8B8",
@@ -42,6 +46,8 @@ module.exports = {
           darkGrey: "#777777",
           // Text (body / secondary copy)
           textGray: "#6A6A6A",
+          /** Desktop heading / m-reg (Figma) */
+          heading: "#2E2E2E",
           neutral: {
             dark: "#2A2A2A",
             muted: "#D9D9D9",
@@ -73,6 +79,9 @@ module.exports = {
         "footer-section-title-mobile": ["18px", { lineHeight: "1.3", letterSpacing: "-0.36px" }],
         "footer-headline": ["48px", { lineHeight: "1.2", letterSpacing: "-0.96px", fontWeight: "700" }],
         "footer-headline-mobile": ["28px", { lineHeight: "1.2", letterSpacing: "-0.56px", fontWeight: "700" }],
+        /** Projects & pages — desktop/heading/m-reg */
+        "heading-m-reg": ["48px", { lineHeight: "1.2", letterSpacing: "-0.96px", fontWeight: "400" }],
+        "heading-m-reg-mobile": ["28px", { lineHeight: "1.2", letterSpacing: "-0.56px", fontWeight: "400" }],
         "footer-logo-desktop": ["24.35px", { letterSpacing: "-0.24px", fontWeight: "500" }],
         "footer-logo-mobile": ["18px", { letterSpacing: "-0.18px", fontWeight: "500" }],
         "nav-link": ["14px", { lineHeight: "100%", fontWeight: "500" }],


### PR DESCRIPTION
## Summary
Adds a light-surface variant to the shared Filters component for use on light/white pages (gray default + light-blue selected), keeps the existing dark variant for dark or patterned backgrounds, and wires Projects to the light variant with Figma-aligned typography and labels.

## Context
- Design tokens and layout were aligned with Figma (pill size, 10px radius, spacing, Blueprint colors).
- Dark and light pills now share the same `pillLayout` so dimensions match across variants; only colors differ by context.

## Changes

### Filters.tsx
- `variant="light"` with `state="default" | "selected"`
  - Default: translucent gray + border  
  - Selected: light blue border + very light blue fill  
- `variant="dark"` (default)
  - Unchanged behavior: outlined (white border + white/20) and filled (solid white)
- Shared `pillLayout` for consistent height, padding, gap, and radius (including below desktop breakpoint)

### ProjectsPage.tsx
- Filters use `variant="light"` with local selection state and `gap-[10px]`
- Labels: **Web-App**, **Website**, **Plug-In** (hyphens per copy)
- Heading “our projects” uses:
  - `desktop/heading/m-reg`
  - Poppins, 48px (desktop)
  - Color: `#2E2E2E`
  - Center aligned

### tailwind.config.js
- `blueprint.filterOnWhite` — border + default pill background for light filters
- `blueprint.heading` — `#2E2E2E`
- `text-heading-m-reg` / `text-heading-m-reg-mobile` — heading scale + tracking

## How to Test
- `/projectspage`
  - Confirm filters, selection, heading, and layout on light gray/pattern background
- Any page using `variant="dark"`
  - Confirm outlined/filled pills remain unchanged

## Screenshots
<img width="493" height="412" alt="image" src="https://github.com/user-attachments/assets/e6ced95b-3cbd-4319-9120-84b2120c3b28" />


Closes #69 