### PR TITLE
feat(nav): Figma-aligned NavBar — mobile single container, desktop la…

### DIFF
--- a/src/assets/icons/hamburger-dark.svg
+++ b/src/assets/icons/hamburger-dark.svg
@@ -1,0 +1,10 @@
+<svg width="800px" height="800px" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" fill="#FFFFFF" stroke="#FFFFFF">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier">
+<title>Menu (dark surface)</title>
+<path d="M41,14H7a2,2,0,0,1,0-4H41A2,2,0,0,1,41,14Z" fill="#6f7380"/>
+<path d="M41,26H7a2,2,0,0,1,0-4H41A2,2,0,0,1,41,26Z" fill="#6f7380"/>
+<path d="M41,38H7a2,2,0,0,1,0-4H41A2,2,0,0,1,41,38Z" fill="#6f7380"/>
+</g>
+</svg>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,142 +2,216 @@ import React, { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { ReactComponent as MenuHamburgerIcon } from "../assets/icons/hamburger.svg";
 import { ReactComponent as MenuXIcon } from "../assets/icons/x.svg";
-import { ReactComponent as GrayMenuHamburgerIcon } from "../assets/icons/TEMP_hamburger_gray.svg"
-import { ReactComponent as GrayMenuXIcon } from "../assets/icons/x_gray.svg"
+import { ReactComponent as HamburgerIconDark } from "../assets/icons/hamburger-dark.svg";
+import { ReactComponent as MenuXIconDark } from "../assets/icons/x_gray.svg";
 import Logo from "./shared/Logo";
 
-interface NavBarProps {
+/** Mobile unified card + desktop nav link surfaces */
+const NAV_SURFACE_SHADOW =
+  "shadow-[0px_4px_15px_0px_rgba(0,0,0,0.07)]";
+
+const ROUTES = [
+  { name: "Home", path: "/" },
+  { name: "Projects", path: "/projectspage" },
+  { name: "For Non Profits", path: "/nonprofits" },
+  { name: "For Students", path: "/students" },
+  { name: "About Us", path: "/about" },
+] as const;
+
+export interface NavBarProps {
+  /** e.g. Students page — outer strip `bp-darkest-grey`, cards `bp-black` */
   isDark?: boolean;
 }
 
 const NavBar = ({ isDark = false }: NavBarProps) => {
   const [isMenuOpened, setIsMenuOpened] = useState(false);
-
-  const toggleMenu = () => {
-    setIsMenuOpened((prev) => !prev);
-  };
-
-  const closeMenu = () => {
-    setIsMenuOpened(false);
-  };
-
+  const toggleMenu = () => setIsMenuOpened((prev) => !prev);
+  const closeMenu = () => setIsMenuOpened(false);
   const currentPath = useLocation().pathname;
 
-  // Define nav links in one place
-  const routes = [
-    { name: "Home", path: "/" },
-    { name: "Projects", path: "/projectspage" },
-    { name: "For Non Profits", path: "/nonprofits" },
-    { name: "For Students", path: "/students" },
-    { name: "About Us", path: "/about" },
-  ];
+  const surfaceClass = isDark ? "bg-blueprint-black" : "bg-blueprint-white";
 
   return (
-    <nav className="w-full p-5 justify-center">
-      <div className="flex flex-col gap-4 max-lg:flex-grow lg:flex-row lg:gap-0 lg:items-stretch w-full max-w-full px-2 md:px-6 xl:px-32 mx-auto">
-      <div className={`flex justify-between items-center rounded-[5px]
-                      ${isDark ? 'bg-blueprint-black' : 'bg-blueprint-white shadow-[0px_4px_15px_0px_rgba(0,0,0,0.07)]'}
-                      backdrop-blur-xl overflow-hidden max-lg:pr-4`}>
-
-        <div>
+    <nav className="w-full justify-center p-5" aria-label="Primary">
+      <div className="mx-auto flex w-full max-w-full flex-col gap-4 max-lg:flex-grow px-2 md:px-6 xl:px-32 lg:flex-row lg:items-stretch lg:gap-0">
+        {/* Desktop (lg+): original layout — logo card, flex spacer, compact nav card (hugs links, not full width) */}
+        <div
+          className={`hidden items-center justify-between overflow-hidden rounded-[5px] backdrop-blur-xl lg:flex lg:shrink-0 ${
+            isDark
+              ? "bg-blueprint-black"
+              : `bg-blueprint-white ${NAV_SURFACE_SHADOW}`
+          }`}
+        >
           <Logo isDark={isDark} />
         </div>
-
-        <div>
-          <MenuButton
+        <div className="hidden min-w-0 flex-1 lg:block" aria-hidden />
+        <div
+          className={`hidden items-center overflow-hidden backdrop-blur-xl lg:flex lg:shrink-0 lg:rounded-lg ${
+            isDark
+              ? "rounded-[10px] bg-blueprint-neutral-dark"
+              : `bg-blueprint-white ${NAV_SURFACE_SHADOW}`
+          }`}
+        >
+          <DesktopNavLinks
+            routes={ROUTES}
+            currentPath={currentPath}
             isDark={isDark}
-            visibility="lg:hidden"
-            isMenuOpened={isMenuOpened}
-            toggleMenu={toggleMenu}
+            closeMenu={closeMenu}
           />
         </div>
-      </div>
-      <div className="hidden lg:block flex-1" aria-hidden />
-      <div className={`flex justify-between items-center
-                        ${isDark ? 'bg-blueprint-neutral-dark rounded-[10px]' : 'bg-blueprint-white rounded-lg shadow-[0px_4px_15px_0px_rgba(0,0,0,0.07)]'}
-                      backdrop-blur-xl overflow-hidden max-lg:w-full`}>
-        <NavLinks
-          isMenuOpened={isMenuOpened}
-          isDark={isDark}
-          routes={routes}
-          closeMenu={closeMenu}
-          currentPath={currentPath}
-        />
+
+        {/* Mobile (max-lg): single extended card — top row + stacked pills inside same surface */}
+        <div className="lg:hidden">
+          <div
+            className={`overflow-hidden rounded-lg ${NAV_SURFACE_SHADOW} ${surfaceClass}`}
+          >
+            <div
+              className={`flex flex-col gap-3 pt-2 pr-4 pl-4 ${
+                isMenuOpened ? "pb-6" : "pb-2"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <Logo isDark={isDark} />
+                <MenuButton
+                  isDark={isDark}
+                  isMenuOpened={isMenuOpened}
+                  toggleMenu={toggleMenu}
+                />
+              </div>
+              {isMenuOpened ? (
+                <div className="flex flex-col gap-1">
+                  <MobileNavLinks
+                    routes={ROUTES}
+                    currentPath={currentPath}
+                    isDark={isDark}
+                    closeMenu={closeMenu}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
         </div>
       </div>
     </nav>
   );
 };
 
-function MenuButton({ isMenuOpened, visibility, toggleMenu, isDark }) {
+type RouteItem = (typeof ROUTES)[number];
+
+function MenuButton({
+  isMenuOpened,
+  toggleMenu,
+  isDark,
+}: {
+  isMenuOpened: boolean;
+  toggleMenu: () => void;
+  isDark: boolean;
+}) {
   return (
     <button
-      className={`${visibility} w-10 h-10 rounded-[7.05px] p-[13px_11px] gap-[9px] flex items-center justify-center transition-colors ${
-        isDark ? 'bg-blueprint-neutral-dark' : 'bg-blueprint-white'
+      type="button"
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg p-2 transition-colors ${
+        isDark ? "bg-blueprint-darkestGrey" : "bg-blueprint-gray-light"
       }`}
       onClick={toggleMenu}
+      aria-expanded={isMenuOpened}
       aria-label={isMenuOpened ? "Close menu" : "Open menu"}
     >
-      
       {isMenuOpened ? (
-        isDark ? <GrayMenuXIcon/>:<MenuXIcon />  
-      ):(
-         isDark ? <GrayMenuHamburgerIcon/>: <MenuHamburgerIcon /> 
+        isDark ? (
+          <MenuXIconDark className="h-[23px] w-[23px]" />
+        ) : (
+          <MenuXIcon className="h-[23px] w-[23px]" />
+        )
+      ) : isDark ? (
+        <HamburgerIconDark className="h-[23px] w-[23px]" />
+      ) : (
+        <MenuHamburgerIcon className="h-[23px] w-[23px]" />
       )}
     </button>
   );
 }
 
-function NavLinks({ routes, isMenuOpened, currentPath, closeMenu, isDark}) {
+function DesktopNavLinks({
+  routes,
+  currentPath,
+  closeMenu,
+  isDark,
+}: {
+  routes: readonly RouteItem[];
+  currentPath: string;
+  closeMenu: () => void;
+  isDark: boolean;
+}) {
   return (
-    // MENU BUTTON
-    <div
-      className={`flex flex-col max-lg:items-stretch max-lg:w-full items-center font-poppins lg:flex-row lg:space-x-12 lg:flex ${
-        isMenuOpened ? "" : "max-lg:hidden"
-      }`}
-    >
-      {/* MOBILE WRAPPER */}
-      <div className={`
-        max-lg:w-full max-lg:px-4
-        ${isDark ? 'max-lg:bg-blueprint-neutral-dark max-lg:py-3 max-lg:pb-6 max-lg:space-y-1' : 'max-lg:bg-white max-lg:py-2 max-lg:space-y-2'}
-        lg:contents
-      `}>
-        {routes.map((route, index) => (
+    <div className="flex flex-row flex-wrap items-center justify-end space-x-12">
+      {routes.map((route, index) => {
+        if (index === 0) return null;
+        const isActive = route.path === currentPath;
+        return (
           <Link
-            key={index}
+            key={route.path}
             to={route.path}
             onClick={closeMenu}
-            // max-lg - Mobile width
-            // lg - desktop width
-            className={`
-              max-lg:w-full max-lg:h-nav-mobile-h max-lg:px-nav-mobile-px max-lg:py-nav-mobile-py
-              max-lg:flex max-lg:items-center max-lg:justify-start
-              max-lg:rounded-md max-lg:text-left 
-              max-lg:active:text-white
-              max-lg:hover:text-white
-              ${isDark ? 'max-lg:active:bg-blueprint-neutral-mutedAlt max-lg:hover:bg-blueprint-neutral-mid max-lg:bg-blueprint-neutral-dark max-lg:text-blueprint-gray-lightest' :
-                'max-lg:active:bg-blueprint-linkActive max-lg:hover:bg-blueprint-linkHover max-lg:bg-blueprint-gray-light max-lg:text-blueprint-black'}
-              ${route.path === currentPath ? 'max-lg:font-semibold max-lg:text-blueprint-blue' : ''}
-               
-              lg:relative lg:h-nav-desktop-h lg:px-nav-desktop-px lg:py-nav-desktop-py
-              lg:flex lg:items-center lg:justify-between
-              lg:bg-transparent lg:hover:text-white lg:active:text-white
-              ${isDark ? 'lg:text-white lg:hover:bg-blueprint-neutral-mid lg:active:bg-blueprint-neutral-mutedAlt' : 'lg:hover:bg-blueprint-linkHover lg:active:bg-blueprint-linkActive'}
-              lg:rounded lg:transition-all
-              
-              ${route.path === currentPath && "text-blueprint-blue font-semibold"}
-              ${index === 0 && "lg:hidden"}
-              
-              font-poppins text-nav-link uppercase
-              whitespace-nowrap
-              transition-all
-            `}
+            className={[
+              "relative flex items-center whitespace-nowrap rounded font-poppins text-nav-link uppercase transition-all",
+              "h-nav-desktop-h px-nav-desktop-px py-nav-desktop-py",
+              isDark
+                ? "text-white hover:bg-blueprint-neutral-mid hover:text-white active:bg-blueprint-neutral-mutedAlt active:text-white"
+                : "text-blueprint-black hover:bg-blueprint-linkHover hover:text-white active:bg-blueprint-linkActive active:text-white",
+              isActive
+                ? "font-semibold text-blueprint-blue hover:text-white"
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
           >
             {route.name}
           </Link>
-        ))}
-      </div>
+        );
+      })}
     </div>
   );
 }
+
+function MobileNavLinks({
+  routes,
+  currentPath,
+  closeMenu,
+  isDark,
+}: {
+  routes: readonly RouteItem[];
+  currentPath: string;
+  closeMenu: () => void;
+  isDark: boolean;
+}) {
+  return (
+    <>
+      {routes.map((route) => {
+        const isActive = route.path === currentPath;
+        return (
+          <Link
+            key={route.path}
+            to={route.path}
+            onClick={closeMenu}
+            className={[
+              "flex h-nav-mobile-h items-center justify-start rounded-md px-nav-mobile-px py-nav-mobile-py font-poppins text-nav-link uppercase transition-all",
+              isDark
+                ? "bg-blueprint-darkestGrey text-white hover:bg-blueprint-neutral-mid hover:text-white active:bg-blueprint-neutral-mutedAlt active:text-white"
+                : "bg-blueprint-gray-light text-blueprint-black hover:bg-blueprint-linkHover hover:text-white active:bg-blueprint-linkActive active:text-white",
+              isActive
+                ? "font-semibold text-blueprint-blue hover:text-white"
+                : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {route.name}
+          </Link>
+        );
+      })}
+    </>
+  );
+}
+
 export default NavBar;


### PR DESCRIPTION
## Summary
Refactors NavBar so layout and spacing match the approved Figma behavior: desktop keeps the original compact pattern (logo card, flex spacer, right-aligned link cluster), while mobile uses one rounded, shadowed card with the logo + menu control on the first row and stacked pill links below when the menu is open.

## Problem
- Desktop and mobile were handled too similarly; mobile needed a single extended container after opening the menu, not two separate blocks.
- A full-width desktop link bar made the nav feel too long compared to the previous design.
- Dark-mode surfaces and drop shadow needed to stay consistent with the light variant.

## What Changed

### Structure

#### Desktop (lg+)
- Logo in its own surface (`rounded-[5px]`)
- `flex-1` spacer
- Shrink-wrapped link surface (`rounded-lg` / `rounded-[10px]` in dark)
- No full-width stretching of the link bar
- Inline links use `space-x-12` (restores previous behavior)

#### Mobile (max-lg)
- Single card layout:
  - `flex justify-between` for logo + hamburger
  - `gap-3` between header and list
  - `gap-1` between pills
- Padding:
  - `pt-2 pr-4 pl-4`
  - `pb-6` when open
  - `pb-2` when closed
- Menu behavior:
  - Opens into one extended container
  - Pills stack vertically inside the same card

### Theming & Assets
- Supports `isDark` (e.g., Students page)
  - Uses `bp-black` / `bp-neutral-dark` surfaces
  - Applies shared shadow: `shadow-[0px_4px_15px_0px_rgba(0,0,0,0.07)]`
- Adds `hamburger-dark.svg` for dark mode
- Removes dependency on old TEMP hamburger asset

### API
- `NavBarProps` unchanged
- `isDark` usage unchanged (compatible with `App.tsx`)

## How to Test

### Desktop
- Resize above `lg`
- Confirm:
  - Logo on the left
  - Compact link group on the right
  - Link container does **not** stretch full width

### Mobile
- Resize below `lg`
- Open menu:
  - One card expands
  - Pills stack inside
- Close menu:
  - Collapses back to single top row

### /students (Dark Mode)
- Verify:
  - Dark surfaces render correctly
  - Icons (including hamburger) match dark theme
  - Shadow consistency matches light variant

## Screenshots
<img width="253" height="439" alt="image" src="https://github.com/user-attachments/assets/e6eb0842-d25a-488b-8f23-20993f21853c" />
