### PR TITLE
fix: stable tab layout + underline sizing (NavigationTabs + Students)

### DIFF
--- a/src/components/shared/NavigationTabs.tsx
+++ b/src/components/shared/NavigationTabs.tsx
@@ -15,10 +15,10 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
   const [underlineWidth, setUnderlineWidth] = useState(0);
 
   const activeIndex = activeHref != null ? tabs.findIndex((t) => t.href === activeHref) : -1;
-  const effectiveIndex = activeIndex >= 0 ? activeIndex : 0;
 
   useEffect(() => {
-    const textEl = textRefs.current[effectiveIndex];
+    if (activeIndex < 0) return;
+    const textEl = textRefs.current[activeIndex];
     const container = containerRef.current;
     if (textEl && container) {
       const containerRect = container.getBoundingClientRect();
@@ -26,7 +26,7 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
       setUnderlineLeft(textRect.left - containerRect.left - UNDERLINE_EXTRA_PX);
       setUnderlineWidth(textRect.width + UNDERLINE_EXTRA_PX * 2);
     }
-  }, [effectiveIndex, tabs]);
+  }, [activeIndex, tabs]);
 
   return (
     <nav className="w-full font-poppins" aria-label="Section navigation">
@@ -40,13 +40,13 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
             <Link
               key={tab.href}
               to={tab.href}
-              className={`group relative block shrink-0 py-3 px-4 text-sm leading-[100%] tracking-normal whitespace-nowrap transition-colors duration-150 ${
+              className={`group relative inline-flex shrink-0 w-fit max-w-fit py-3 px-4 text-sm leading-[100%] tracking-normal whitespace-nowrap transition-colors duration-150 ${
                 isActive ? "text-blueprint-linkHover" : "text-blueprint-neutral-dark"
               }`}
               aria-current={isActive ? "page" : undefined}
             >
               <span
-                className="relative inline-block"
+                className="relative inline-block w-max"
                 ref={(el) => {
                   textRefs.current[i] = el;
                 }}
@@ -55,7 +55,7 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
                   {tab.label}
                 </span>
                 <span
-                  className={`absolute inset-0 flex items-center ${isActive ? "font-semibold" : "font-normal group-hover:font-semibold"}`}
+                  className={`absolute inset-0 flex items-center justify-center ${isActive ? "font-semibold" : "font-normal group-hover:font-semibold"}`}
                 >
                   {tab.label}
                 </span>

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useLayoutEffect, useCallback } from "react";
 import CalloutCard from "../components/shared/CalloutCard";
 import Button from "../components/shared/Button";
 import OpenRoleCard from "../components/shared/OpenRoleCard";
@@ -418,32 +418,38 @@ const StudentsPage = () => {
   );
 };
 
+/** Reserve semibold width so tabs don’t shift when active/hover bolds the label. */
+const APPLICATION_TAB_UNDERLINE_EXTRA_PX = 8;
+
 function ApplicationProcessSection() {
   const [activeTab, setActiveTab] = useState<string>("MEET BLUEPRINT");
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 160 });
+  const indicatorContainerRef = useRef<HTMLDivElement | null>(null);
+  const tabsScrollRef = useRef<HTMLDivElement | null>(null);
+  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
 
   const updateIndicator = useCallback(() => {
     const activeIndex = APPLICATION_TABS.indexOf(activeTab as typeof APPLICATION_TABS[number]);
     const tabEl = tabRefs.current[activeIndex];
-    if (tabEl) {
-      const parent = tabEl.parentElement;
-      if (parent) {
-        const parentRect = parent.getBoundingClientRect();
-        const tabRect = tabEl.getBoundingClientRect();
-        const tabCenter = tabRect.left - parentRect.left + tabRect.width / 2;
-        setIndicatorStyle({
-          left: tabCenter - 80,
-          width: 160,
-        });
-      }
-    }
+    const container = indicatorContainerRef.current;
+    if (!tabEl || !container) return;
+    const containerRect = container.getBoundingClientRect();
+    const tabRect = tabEl.getBoundingClientRect();
+    setIndicatorStyle({
+      left: tabRect.left - containerRect.left - APPLICATION_TAB_UNDERLINE_EXTRA_PX,
+      width: tabRect.width + APPLICATION_TAB_UNDERLINE_EXTRA_PX * 2,
+    });
   }, [activeTab]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     updateIndicator();
     window.addEventListener("resize", updateIndicator);
-    return () => window.removeEventListener("resize", updateIndicator);
+    const scrollEl = tabsScrollRef.current;
+    scrollEl?.addEventListener("scroll", updateIndicator, { passive: true });
+    return () => {
+      window.removeEventListener("resize", updateIndicator);
+      scrollEl?.removeEventListener("scroll", updateIndicator);
+    };
   }, [updateIndicator]);
 
   const renderTabContent = () => {
@@ -494,30 +500,48 @@ function ApplicationProcessSection() {
       <div className="flex flex-col gap-[21px]">
         {/* Tab bar */}
         <div className="flex flex-col gap-[8px]">
-          <div className="flex gap-[60px] max-md:gap-[24px] pl-[16px] overflow-x-auto">
-            {APPLICATION_TABS.map((tab, i) => (
-              <button
-                key={tab}
-                ref={(el) => { tabRefs.current[i] = el; }}
-                onClick={() => setActiveTab(tab)}
-                className={`font-poppins text-[16px] max-md:text-[14px] whitespace-nowrap cursor-pointer bg-transparent border-none p-0 ${
-                  activeTab === tab
-                    ? "font-semibold text-[#0146be]"
-                    : "font-normal text-[#2a2a2a]"
-                }`}
-              >
-                {tab}
-              </button>
-            ))}
+          <div
+            ref={tabsScrollRef}
+            className="flex gap-[60px] max-md:gap-[24px] pl-[16px] overflow-x-auto"
+          >
+            {APPLICATION_TABS.map((tab, i) => {
+              const isSelected = activeTab === tab;
+              return (
+                <button
+                  key={tab}
+                  type="button"
+                  ref={(el) => {
+                    tabRefs.current[i] = el;
+                  }}
+                  onClick={() => setActiveTab(tab)}
+                  className="group relative inline-flex shrink-0 cursor-pointer border-none bg-transparent p-0 font-poppins text-[16px] max-md:text-[14px] whitespace-nowrap"
+                >
+                  <span className="relative inline-block w-max">
+                    <span className="font-semibold invisible select-none" aria-hidden>
+                      {tab}
+                    </span>
+                    <span
+                      className={`absolute inset-0 flex items-center justify-center ${
+                        isSelected
+                          ? "font-semibold text-[#0146be]"
+                          : "font-normal text-[#2a2a2a] group-hover:font-semibold"
+                      }`}
+                    >
+                      {tab}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
           </div>
           {/* Tab indicator line */}
-          <div className="relative w-full">
+          <div ref={indicatorContainerRef} className="relative w-full">
             <div
               className="absolute top-0 h-[5px] bg-[#0146be] rounded-t-[10px]"
               style={{
                 left: indicatorStyle.left,
                 width: indicatorStyle.width,
-                transition: "left 0.2s ease",
+                transition: "left 0.2s ease, width 0.2s ease",
               }}
             />
             <div className="w-full h-px bg-[#aaaaaa] mt-[5px]" />


### PR DESCRIPTION
- NavigationTabs: inline-flex w-fit, justify-center overlay, measure activeIndex only
- Students application process: semibold ghost width (no shift on active/hover), measured indicator + scroll/resize, underline fixed
<img width="1728" height="415" alt="image" src="https://github.com/user-attachments/assets/b342bc68-754f-4cdb-8191-133bf4694594" />

<img width="902" height="324" alt="image" src="https://github.com/user-attachments/assets/4ea7ab86-0a88-4525-9948-10dab18c3ca3" />
