### PR TITLE
New Updated NPO page with new proposal section (still old footer section)

### DIFF
--- a/src/components/Common.jsx
+++ b/src/components/Common.jsx
@@ -4,7 +4,7 @@ const PageHeader = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={`${props.className} text-blueprint-black font-anek text-[2rem] md:text-[4rem] leading-tight font-semibold`}
+      className={`${props.className} text-bp-black font-anek text-[2rem] md:text-[4rem] leading-tight font-semibold`}
     />
   );
 };
@@ -13,7 +13,7 @@ const SectionHeader = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={`${props.className} text-blueprint-black font-anek text-[21px] md:text-[3rem] leading-tight font-[550]`}
+      className={`${props.className} text-bp-black font-anek text-[21px] md:text-[3rem] leading-tight font-[550]`}
     />
   );
 };
@@ -22,7 +22,7 @@ const ParagraphTitle = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={`${props.className} text-blueprint-blue font-poppins text-[1rem] md:text-[1.5rem] font-medium leading-tight uppercase`}
+      className={`${props.className} text-bp-blue font-poppins text-[1rem] md:text-[1.5rem] font-medium leading-tight uppercase`}
     />
   );
 };
@@ -31,7 +31,7 @@ const ParagraphText = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={` ${props.className} text-blueprint-black font-poppins text-[0.75rem] md:text-[1rem] leading-normal`}
+      className={` ${props.className} text-bp-black font-poppins text-[0.75rem] md:text-[1rem] leading-normal`}
     />
   );
 };
@@ -40,7 +40,7 @@ const ButtonText = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={` ${props.className} text-blueprint-blue font-poppins text-[0.75rem] md:text-[1rem] font-semibold leading-normal`}
+      className={` ${props.className} text-bp-blue font-poppins text-[0.75rem] md:text-[1rem] font-semibold leading-normal`}
     />
   );
 };
@@ -49,7 +49,7 @@ const Annotation = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={` ${props.className} text-blueprint-black font-sketch text-[0.75rem] md:text-[1rem] leading-tight`}
+      className={` ${props.className} text-bp-black font-sketch text-[0.75rem] md:text-[1rem] leading-tight`}
     />
   );
 };
@@ -58,7 +58,7 @@ const Landing = ({ ...props }) => {
   return (
     <p
       {...props}
-      className={` ${props.className} text-blueprint-blue font-anek text-[62px] md:text-[122px] tracking-tight leading-none`}
+      className={` ${props.className} text-bp-blue font-anek text-[62px] md:text-[122px] tracking-tight leading-none`}
     />
   );
 };

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -19,7 +19,7 @@ const ROUTES = [
 ] as const;
 
 export interface NavBarProps {
-  /** e.g. Students page — outer strip `bp-darkest-grey`, cards `bp-black` */
+  /** e.g. Students page — outer strip bp-black, cards bp-black */
   isDark?: boolean;
 }
 
@@ -29,7 +29,7 @@ const NavBar = ({ isDark = false }: NavBarProps) => {
   const closeMenu = () => setIsMenuOpened(false);
   const currentPath = useLocation().pathname;
 
-  const surfaceClass = isDark ? "bg-blueprint-black" : "bg-blueprint-white";
+  const surfaceClass = isDark ? "bg-bp-black" : "bg-bp-white";
 
   return (
     <nav className="w-full justify-center p-5" aria-label="Primary">
@@ -38,8 +38,8 @@ const NavBar = ({ isDark = false }: NavBarProps) => {
         <div
           className={`hidden items-center justify-between overflow-hidden rounded-[5px] backdrop-blur-xl lg:flex lg:shrink-0 ${
             isDark
-              ? "bg-blueprint-black"
-              : `bg-blueprint-white ${NAV_SURFACE_SHADOW}`
+              ? "bg-bp-black"
+              : `bg-bp-white ${NAV_SURFACE_SHADOW}`
           }`}
         >
           <Logo isDark={isDark} />
@@ -48,8 +48,8 @@ const NavBar = ({ isDark = false }: NavBarProps) => {
         <div
           className={`hidden items-center overflow-hidden backdrop-blur-xl lg:flex lg:shrink-0 lg:rounded-lg ${
             isDark
-              ? "rounded-[10px] bg-blueprint-neutral-dark"
-              : `bg-blueprint-white ${NAV_SURFACE_SHADOW}`
+              ? "rounded-[10px] bg-bp-black"
+              : `bg-bp-white ${NAV_SURFACE_SHADOW}`
           }`}
         >
           <DesktopNavLinks
@@ -111,7 +111,7 @@ function MenuButton({
     <button
       type="button"
       className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg p-2 transition-colors ${
-        isDark ? "bg-blueprint-darkestGrey" : "bg-blueprint-gray-light"
+        isDark ? "bg-bp-darkest-grey" : "bg-bp-lightest-grey"
       }`}
       onClick={toggleMenu}
       aria-expanded={isMenuOpened}
@@ -157,10 +157,10 @@ function DesktopNavLinks({
               "relative flex items-center whitespace-nowrap rounded font-poppins text-nav-link uppercase transition-all",
               "h-nav-desktop-h px-nav-desktop-px py-nav-desktop-py",
               isDark
-                ? "text-white hover:bg-blueprint-neutral-mid hover:text-white active:bg-blueprint-neutral-mutedAlt active:text-white"
-                : "text-blueprint-black hover:bg-blueprint-linkHover hover:text-white active:bg-blueprint-linkActive active:text-white",
+                ? "text-white hover:bg-bp-dark-grey hover:text-white active:bg-bp-grey active:text-white"
+                : "text-bp-black hover:bg-bp-blue hover:text-white active:bg-bp-pressed-blue active:text-white",
               isActive
-                ? "font-semibold text-blueprint-blue hover:text-white"
+                ? "font-semibold text-bp-blue hover:text-white"
                 : "",
             ]
               .filter(Boolean)
@@ -197,10 +197,10 @@ function MobileNavLinks({
             className={[
               "flex h-nav-mobile-h items-center justify-start rounded-md px-nav-mobile-px py-nav-mobile-py font-poppins text-nav-link uppercase transition-all",
               isDark
-                ? "bg-blueprint-darkestGrey text-white hover:bg-blueprint-neutral-mid hover:text-white active:bg-blueprint-neutral-mutedAlt active:text-white"
-                : "bg-blueprint-gray-light text-blueprint-black hover:bg-blueprint-linkHover hover:text-white active:bg-blueprint-linkActive active:text-white",
+                ? "bg-bp-darkest-grey text-white hover:bg-bp-dark-grey hover:text-white active:bg-bp-grey active:text-white"
+                : "bg-bp-lightest-grey text-bp-black hover:bg-bp-blue hover:text-white active:bg-bp-pressed-blue active:text-white",
               isActive
-                ? "font-semibold text-blueprint-blue hover:text-white"
+                ? "font-semibold text-bp-blue hover:text-white"
                 : "",
             ]
               .filter(Boolean)

--- a/src/components/Notification.jsx
+++ b/src/components/Notification.jsx
@@ -14,7 +14,7 @@ const Notification = ({ message, onClose }) => {
 
   return (
     <div
-      className={`fixed top-0 left-0 right-0 mx-[10%] lg:mx-[20%] mt-24 p-5 rounded-sm bg-blueprint-white shadow-2xl border border-blueprint-gray-light flex justify-between items-center duration-700 transition-opacity ${
+      className={`fixed top-0 left-0 right-0 mx-[10%] lg:mx-[20%] mt-24 p-5 rounded-sm bg-bp-white shadow-2xl border border-bp-lightest-grey flex justify-between items-center duration-700 transition-opacity ${
         closed ? "opacity-0" : "opacity-100"
       }`}
     >

--- a/src/components/about-page/AlumniCard.jsx
+++ b/src/components/about-page/AlumniCard.jsx
@@ -12,7 +12,7 @@ import { ParagraphText } from "../Common";
 const AlumniCard = (props) => {
   return (
     <div>
-      <ParagraphTitle className="!text-blueprint-black !font-bold mb-5">
+      <ParagraphTitle className="!text-bp-black !font-bold mb-5">
         {props.gridName}
       </ParagraphTitle>
 
@@ -29,7 +29,7 @@ const AlumniCard = (props) => {
 					</ParagraphText>
 				</div>
 
-				<ParagraphText className="!text-blueprint-blue underline">
+				<ParagraphText className="!text-bp-blue underline">
 					<a
 						href={card.linkedin}
 						target="_blank"

--- a/src/components/about-page/AlumniGrid.jsx
+++ b/src/components/about-page/AlumniGrid.jsx
@@ -20,7 +20,7 @@ const AlumniGrid = (props) => {
                             <h1 className="font-poppins text-[14px] text-[#6C6B7A]">{items.position}</h1>
                         </div>
                         <div className="flex flex-row ml-5 mb-3 mr-5">
-                            <a className="font-poppins text-blueprint-blue text-[14px] underline" href="">LinkedIn </a>
+                            <a className="font-poppins text-bp-blue text-[14px] underline" href="">LinkedIn </a>
                             <img className="ml-[5%]" src="/share.svg" alt=""/>
                         </div>
                     </div>

--- a/src/components/about-page/CardGrid.jsx
+++ b/src/components/about-page/CardGrid.jsx
@@ -16,7 +16,7 @@ const CardGrid = (props) => {
 
   return (
     <div>
-      <ParagraphTitle className="!text-blueprint-black !font-bold mb-2">
+      <ParagraphTitle className="!text-bp-black !font-bold mb-2">
         {props.gridName}
       </ParagraphTitle>
 

--- a/src/components/about-page/CardItem.jsx
+++ b/src/components/about-page/CardItem.jsx
@@ -44,7 +44,7 @@ const CardItem = React.memo((props) => {
         )}
 
         {props.lastPosition !== "" && (
-          <ParagraphText className="font-poppins text-blueprint-gray-dark flex justify-center">
+          <ParagraphText className="font-poppins text-bp-grey flex justify-center">
             {props.lastPosition}
           </ParagraphText>
         )}

--- a/src/components/about-page/Gears/Gear.css
+++ b/src/components/about-page/Gears/Gear.css
@@ -3,7 +3,7 @@
 }
 
 .gear .text {
-    @apply text-blueprint-blue text-2xl font-poppins absolute;
+    @apply text-bp-blue text-2xl font-poppins absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -12,7 +12,7 @@
 }
 
 .gear .line{
-    @apply bg-blueprint-blue absolute;
+    @apply bg-bp-blue absolute;
     content: '';
     height: 3px;
     top: 50%;

--- a/src/components/about-page/Gears/MobileGearSection.css
+++ b/src/components/about-page/Gears/MobileGearSection.css
@@ -1,7 +1,7 @@
 @import "GearSection.css";
 
 .gear-section .mobile-value-title {
-  @apply font-poppins font-medium text-xl text-blueprint-blue mt-6;
+  @apply font-poppins font-medium text-xl text-bp-blue mt-6;
 }
 
 .gear-section .mobile-value-body {

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
   const { t } = useTranslation();
 
   return (
-    <footer className="inset-x-0 bottom-0 h-fit p-14 bg-blueprint-blue text-blueprint-white font-poppins">
+    <footer className="inset-x-0 bottom-0 h-fit p-14 bg-bp-blue text-bp-white font-poppins">
       {/* Render page links */}
       <div className="page-links">
         {t("pages").map(

--- a/src/components/footer/FooterRevamp.tsx
+++ b/src/components/footer/FooterRevamp.tsx
@@ -26,10 +26,10 @@ function FooterLink({ name, path }: { name: string; path: string }) {
       className="relative flex items-center group"
     >
       <div
-        className="absolute -left-[30px] w-[18px] h-[18px] rounded-[3px] bg-blueprint-accent-purple opacity-0 group-hover:opacity-100 transition-opacity"
+        className="absolute -left-[30px] w-[18px] h-[18px] rounded-[3px] bg-bp-accent-purple opacity-0 group-hover:opacity-100 transition-opacity"
       />
       <span
-        className="font-poppins text-body-l-reg text-blueprint-darkGrey group-hover:text-blueprint-black transition-colors"
+        className="font-poppins text-body-l-reg text-bp-dark-grey group-hover:text-bp-black transition-colors"
       >
         {name}
       </span>
@@ -50,7 +50,7 @@ export default function FooterRevamp() {
               <div className="flex items-center justify-between">
                 <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
                   <LogoIcon className="w-[33px] h-[31px]" style={{ fill: '#0146BE' }} />
-                  <span className="text-footer-logo-desktop text-blueprint-navyblue">blueprint</span>
+                  <span className="text-footer-logo-desktop text-bp-blue">blueprint</span>
                 </Link>
 
                 <div className="flex items-center gap-[22.74px]">
@@ -60,7 +60,7 @@ export default function FooterRevamp() {
                       href={social.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`${social.name === "Discord" ? "w-[33px] h-[28px]" : "w-[33px] h-[27px]"} text-blueprint-darkGrey hover:text-blueprint-black transition-colors`}
+                      className={`${social.name === "Discord" ? "w-[33px] h-[28px]" : "w-[33px] h-[27px]"} text-bp-dark-grey hover:text-bp-black transition-colors`}
                       aria-label={social.name}
                     >
                       <social.icon className="w-full h-full" />
@@ -72,10 +72,10 @@ export default function FooterRevamp() {
               {/* Tagline + links */}
               <div className="flex items-start gap-[117px]">
                 <div className="shrink-0">
-                  <p className="font-poppins text-heading-m-reg text-blueprint-black">
+                  <p className="font-poppins text-heading-m-reg text-bp-black">
                     tech for
                   </p>
-                  <p className="font-caveat font-bold text-[80px] leading-[0.7] tracking-[-2.4px] text-blueprint-black">
+                  <p className="font-caveat font-bold text-[80px] leading-[0.7] tracking-[-2.4px] text-bp-black">
                     social good
                   </p>
                 </div>
@@ -90,12 +90,12 @@ export default function FooterRevamp() {
 
             {/* Bottom section */}
             <div className="flex flex-col gap-[24px]">
-              <div className="w-full h-[1px] bg-blueprint-grey" />
-              <div className="flex items-center justify-between text-[14px] font-medium text-blueprint-darkGrey uppercase">
+              <div className="w-full h-[1px] bg-bp-grey" />
+              <div className="flex items-center justify-between text-[14px] font-medium text-bp-dark-grey uppercase">
                 <p>@2025 sfu blueprint</p>
                 <div className="flex items-center gap-[18px]">
-                  <Link to="/privacy" className="hover:text-blueprint-black transition-colors">privacy policy</Link>
-                  <Link to="/terms" className="hover:text-blueprint-black transition-colors">terms and conditions</Link>
+                  <Link to="/privacy" className="hover:text-bp-black transition-colors">privacy policy</Link>
+                  <Link to="/terms" className="hover:text-bp-black transition-colors">terms and conditions</Link>
                 </div>
               </div>
             </div>
@@ -112,7 +112,7 @@ export default function FooterRevamp() {
               <div className="flex items-center justify-between">
                 <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
                   <LogoIcon className="w-[26px] h-[24px]" style={{ fill: '#0146BE' }} />
-                  <span className="text-footer-logo-mobile text-blueprint-navyblue">blueprint</span>
+                  <span className="text-footer-logo-mobile text-bp-blue">blueprint</span>
                 </Link>
 
                 <div className="flex items-center gap-[18px]">
@@ -122,7 +122,7 @@ export default function FooterRevamp() {
                       href={social.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`${social.name === "Discord" ? "w-[27px] h-[23px]" : "w-[27px] h-[22px]"} text-blueprint-darkGrey hover:text-blueprint-black transition-colors`}
+                      className={`${social.name === "Discord" ? "w-[27px] h-[23px]" : "w-[27px] h-[22px]"} text-bp-dark-grey hover:text-bp-black transition-colors`}
                       aria-label={social.name}
                     >
                       <social.icon className="w-full h-full" />
@@ -133,10 +133,10 @@ export default function FooterRevamp() {
 
               {/* Tagline */}
               <div>
-                <p className="font-poppins text-heading-m-reg text-blueprint-black">
+                <p className="font-poppins text-heading-m-reg text-bp-black">
                   tech for
                 </p>
-                <p className="font-caveat font-bold text-[60px] leading-[0.7] tracking-[-1.8px] text-blueprint-black">
+                <p className="font-caveat font-bold text-[60px] leading-[0.7] tracking-[-1.8px] text-bp-black">
                   social good
                 </p>
               </div>
@@ -151,12 +151,12 @@ export default function FooterRevamp() {
 
             {/* Bottom */}
             <div className="flex flex-col gap-[24px]">
-              <div className="w-full h-[1px] bg-blueprint-grey" />
-              <div className="flex items-start justify-between text-[14px] font-medium text-blueprint-darkGrey uppercase">
+              <div className="w-full h-[1px] bg-bp-grey" />
+              <div className="flex items-start justify-between text-[14px] font-medium text-bp-dark-grey uppercase">
                 <p>@2025 sfu blueprint</p>
                 <div className="flex items-center gap-[18px]">
-                  <Link to="/privacy" className="hover:text-blueprint-black transition-colors">privacy policy</Link>
-                  <Link to="/terms" className="hover:text-blueprint-black transition-colors">terms and conditions</Link>
+                  <Link to="/privacy" className="hover:text-bp-black transition-colors">privacy policy</Link>
+                  <Link to="/terms" className="hover:text-bp-black transition-colors">terms and conditions</Link>
                 </div>
               </div>
             </div>
@@ -172,15 +172,15 @@ export default function FooterRevamp() {
             <div className="flex flex-col gap-[44px]">
               <Link to="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
                 <LogoIcon className="w-[23px] h-[21px]" style={{ fill: '#0146BE' }} />
-                <span className="text-footer-logo-mobile text-blueprint-navyblue">blueprint</span>
+                <span className="text-footer-logo-mobile text-bp-blue">blueprint</span>
               </Link>
 
               {/* Tagline */}
               <div>
-                <p className="font-poppins text-mobile-heading-m-reg text-blueprint-black">
+                <p className="font-poppins text-mobile-heading-m-reg text-bp-black">
                   tech for
                 </p>
-                <p className="font-caveat font-bold text-[44px] leading-[0.7] tracking-[-1.32px] text-blueprint-black">
+                <p className="font-caveat font-bold text-[44px] leading-[0.7] tracking-[-1.32px] text-bp-black">
                   social good
                 </p>
               </div>
@@ -194,7 +194,7 @@ export default function FooterRevamp() {
                   href={social.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`${social.name === "Discord" ? "w-[27px] h-[23px]" : "w-[27px] h-[22px]"} text-blueprint-darkGrey hover:text-blueprint-black transition-colors`}
+                  className={`${social.name === "Discord" ? "w-[27px] h-[23px]" : "w-[27px] h-[22px]"} text-bp-dark-grey hover:text-bp-black transition-colors`}
                   aria-label={social.name}
                 >
                   <social.icon className="w-full h-full" />
@@ -208,7 +208,7 @@ export default function FooterRevamp() {
                 <Link
                   key={idx}
                   to={link.path}
-                  className="font-poppins text-mobile-body-l-reg text-blueprint-darkGrey hover:text-blueprint-black transition-colors"
+                  className="font-poppins text-mobile-body-l-reg text-bp-dark-grey hover:text-bp-black transition-colors"
                 >
                   {link.name}
                 </Link>
@@ -217,12 +217,12 @@ export default function FooterRevamp() {
 
             {/* Bottom */}
             <div className="flex flex-col gap-[16px]">
-              <div className="w-full h-[1px] bg-blueprint-grey" />
-              <div className="flex flex-col gap-[6px] text-[10px] font-medium text-blueprint-darkGrey uppercase">
+              <div className="w-full h-[1px] bg-bp-grey" />
+              <div className="flex flex-col gap-[6px] text-[10px] font-medium text-bp-dark-grey uppercase">
                 <p>@2025 sfu blueprint</p>
                 <div className="flex gap-[12px]">
-                  <Link to="/privacy" className="hover:text-blueprint-black transition-colors">privacy policy</Link>
-                  <Link to="/terms" className="hover:text-blueprint-black transition-colors">terms and conditions</Link>
+                  <Link to="/privacy" className="hover:text-bp-black transition-colors">privacy policy</Link>
+                  <Link to="/terms" className="hover:text-bp-black transition-colors">terms and conditions</Link>
                 </div>
               </div>
             </div>

--- a/src/components/home-page/HomeProjectCard.tsx
+++ b/src/components/home-page/HomeProjectCard.tsx
@@ -24,7 +24,7 @@ const ProjectCard = ({project=ProjectInfo}) => { // Change Placeholder Project I
     // Placeholders for images and text
     
     return (
-    <div className="w-80 md:max-w-[865px] min-w-72 md:w-auto md:min-w-[624px] px-6 pt-6 pb-9 md:px-9 md:pt-9 md:pb-12 bg-white rounded-[5px] inline-flex flex-col justify-start items-start gap-2.5 overflow-hidden [@media(hover:hover)]:hover:ring-1 [@media(hover:hover)]:hover:ring-blueprint-neutral-mutedAlt [@media(hover:hover)]:hover:bg-blueprint-gray-light group">
+    <div className="w-80 md:max-w-[865px] min-w-72 md:w-auto md:min-w-[624px] px-6 pt-6 pb-9 md:px-9 md:pt-9 md:pb-12 bg-white rounded-[5px] inline-flex flex-col justify-start items-start gap-2.5 overflow-hidden [@media(hover:hover)]:hover:ring-1 [@media(hover:hover)]:hover:ring-bp-grey [@media(hover:hover)]:hover:bg-bp-lightest-grey group">
         <div className="self-stretch flex flex-col justify-start items-start gap-4 md:gap-5">
            {/*  Hero Image  */}
             <div className="self-stretch h-40 flex flex-col justify-end items-center bg-amber-500 rounded-[5px] overflow-hidden pt-[37px] md:h-80">

--- a/src/components/projects-page/ProjectProjectCard.tsx
+++ b/src/components/projects-page/ProjectProjectCard.tsx
@@ -25,7 +25,7 @@ const ProjectCard = ({project=ProjectInfo}) => { // Change Placeholder Project I
     
     return (
     <div className="px-9 pt-9 pb-12 bg-white rounded-[5px] inline-flex flex-col justify-start items-start gap-2.5 overflow-hidden 
-                    [@media(hover:hover)]:hover:ring-1 [@media(hover:hover)]:hover:ring-blueprint-neutral-mutedAlt [@media(hover:hover)]:hover:bg-blueprint-gray-light group
+                    [@media(hover:hover)]:hover:ring-1 [@media(hover:hover)]:hover:ring-bp-grey [@media(hover:hover)]:hover:bg-bp-lightest-grey group
                     md:w-auto md:max-w-[865px] md:min-w-[460px] md:px-9 md:pt-9 md:pb-12 md:h-[640px]
                     max-[767px]:min-w-[276px] max-[767px]:max-w-[623px]">
         <div className="self-stretch flex flex-col justify-start items-start gap-4 md:gap-5 ">

--- a/src/components/shared/Accordion.tsx
+++ b/src/components/shared/Accordion.tsx
@@ -28,7 +28,7 @@ export default function Accordion({
       {/* Header row — always visible */}
       <div className="flex items-center justify-between w-full">
         <span
-          className="text-blueprint-neutral-dark font-medium leading-[1.3]
+          className="text-bp-black font-medium leading-[1.3]
             text-[18px] tracking-[-0.36px]
             md:text-[24px] md:tracking-normal"
         >
@@ -43,7 +43,7 @@ export default function Accordion({
       {/* Body — shown when open */}
       {isOpen && (
         <div className="w-full shrink-0 md:pr-[90px]">
-          <div className="text-blueprint-neutral-dark font-normal leading-normal text-[14px] md:text-[16px]">
+          <div className="text-bp-black font-normal leading-normal text-[14px] md:text-[16px]">
             {children}
           </div>
         </div>

--- a/src/components/shared/AccordionChevron.tsx
+++ b/src/components/shared/AccordionChevron.tsx
@@ -15,10 +15,10 @@ export default function AccordionChevron({
   const [pressed, setPressed] = useState(false);
 
   const bgClass = pressed
-    ? "bg-blueprint-gray-dark"
+    ? "bg-bp-grey"
     : hovered
-      ? "bg-blueprint-neutral-muted"
-      : "bg-blueprint-gray-light";
+      ? "bg-bp-light-grey"
+      : "bg-bp-lightest-grey";
 
   return (
     <button

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -19,11 +19,11 @@ const Button = ({
     'flex items-center justify-center rounded-[5px] font-poppins font-semibold leading-none px-[44px] h-[52px] text-[14px] md:h-[60px] md:text-[16px] transition-colors duration-150 cursor-pointer select-none whitespace-nowrap';
   const variants = {
     primary:
-      'bg-blueprint-linkHover text-white hover:bg-blueprint-hoverBlue active:bg-blueprint-linkActive',
+      'bg-bp-blue text-white hover:bg-bp-hover-blue active:bg-bp-pressed-blue',
     secondary:
-      'bg-white text-blueprint-linkHover hover:bg-blueprint-neutral-muted active:bg-blueprint-neutral-mutedAlt',
+      'bg-white text-bp-blue hover:bg-bp-light-grey active:bg-bp-grey',
     tertiary:
-      'bg-blueprint-black text-white hover:bg-blueprint-darkGrey active:bg-blueprint-linkActive font',
+      'bg-bp-black text-white hover:bg-bp-dark-grey active:bg-bp-pressed-blue font',
   };
 
   return (

--- a/src/components/shared/CalloutCard.tsx
+++ b/src/components/shared/CalloutCard.tsx
@@ -19,7 +19,7 @@ export type CalloutCardProps = {
 };
 
 const STRIPE_WIDTH_PX = 8;
-const defaultStripeColor = "#0177E8"; // blueprint-blue
+const defaultStripeColor = "#0146BE"; // bp-blue
 
 export default function CalloutCard({
   title,
@@ -40,17 +40,17 @@ export default function CalloutCard({
     isWhite
       ? "bg-white"
       : isDark
-        ? "bg-blueprint-neutral-dark"
-        : "bg-blueprint-gray-light";
+        ? "bg-bp-black"
+        : "bg-bp-lightest-grey";
   const useCustomBg = backgroundColor != null;
   const bgClass = useCustomBg ? "" : defaultBgClass;
 
   const defaultTitleClass = isDark
-    ? "text-blueprint-neutral-muted font-bold text-[24px] uppercase tracking-tight"
-    : "text-blueprint-black font-bold text-[24px] uppercase tracking-tight";
+    ? "text-bp-light-grey font-bold text-[24px] uppercase tracking-tight"
+    : "text-bp-black font-bold text-[24px] uppercase tracking-tight";
   const defaultBodyClass = isDark
-    ? "text-blueprint-neutral-muted text-[16px] font-normal leading-relaxed m-0 whitespace-pre-line"
-    : "text-blueprint-black text-[16px] font-normal leading-relaxed m-0";
+    ? "text-bp-light-grey text-[16px] font-normal leading-relaxed m-0 whitespace-pre-line"
+    : "text-bp-black text-[16px] font-normal leading-relaxed m-0";
 
   const effectiveShowBorder = showBorder ?? isWhite;
   const effectiveBorderColor = borderColor ?? stripeColor;

--- a/src/components/shared/CameraButton.tsx
+++ b/src/components/shared/CameraButton.tsx
@@ -20,13 +20,13 @@ const CameraButton = ({
   const isDesktop = size === 'desktop';
   const dimension = isDesktop ? 'w-[120px] h-[120px]' : 'w-[72px] h-[72px]';
 
-  let bgClass = 'bg-blueprint-linkHover';
+  let bgClass = 'bg-bp-blue';
   let iconColor = 'white';
   if (pressed) {
-    bgClass = 'bg-blueprint-accent-lightBlue';
+    bgClass = 'bg-bp-accent-light-blue';
     iconColor = '#0146BE';
   } else if (hovered) {
-    bgClass = 'bg-blueprint-accent-veryLightBlue';
+    bgClass = 'bg-bp-accent-very-light-blue';
     iconColor = '#0146BE';
   }
 

--- a/src/components/shared/EvaluationCard.tsx
+++ b/src/components/shared/EvaluationCard.tsx
@@ -20,7 +20,7 @@ export type EvaluationCardProps = {
  * EvaluationCard: vertical layout when viewport is tall enough (min-h 32rem),
  * horizontal (tablet) layout when viewport height is below that.
  */
-const EvaluationCard = ({ title, body, colour="blueprint-navyblue" }: EvaluationCardProps) => {
+const EvaluationCard = ({ title, body, colour="bp-blue" }: EvaluationCardProps) => {
     const clipId = useId();
   
     return (

--- a/src/components/shared/EvaluationCard.tsx
+++ b/src/components/shared/EvaluationCard.tsx
@@ -26,7 +26,7 @@ const EvaluationCard = ({ title, body, colour="blueprint-navyblue" }: Evaluation
     return (
       <>
         {/* Consolidated Desktop/Mobile layout */}
-        <div className="inline-flex tablet:hidden desktop:inline-flex max-w-[630px] min-w-[328px] h-[341px] pb-[30px] pt-[42px] px-3 relative bg-white rounded-xl border-2 overflow-hidden flex-col items-start">
+        <div className="inline-flex tablet:hidden desktop:inline-flex max-w-[630px] min-w-[328px] h-[341px] pb-[30px] pt-[42px] px-3 relative bg-white rounded-xl overflow-hidden flex-col items-start">
           <svg className="absolute w-0 h-0" aria-hidden>
             <clipPath id={clipId} clipPathUnits="objectBoundingBox">
               <path d="M 1 0 L 1 0 Q 1 0 1 0 L 1 0.55 Q 1 0.77 0.95 0.78 L 0.06 1 Q 0 1 0 1 L 0 0 Q 0 0 0 0 Z" />
@@ -44,7 +44,7 @@ const EvaluationCard = ({ title, body, colour="blueprint-navyblue" }: Evaluation
         </div>
   
         {/* Tablet layout: shown when lg breakpoint >= width > sm breakpoint (630px - 1280px) */}
-        <div className="hidden max-w-[902px] min-w-[630px] min-h-[145px] pl-3 pr-12 py-3 bg-white rounded-xl overflow-hidden border-2 tablet:inline-flex desktop:hidden flex-col">
+        <div className="hidden max-w-[902px] min-w-[630px] min-h-[145px] pl-3 pr-12 py-3 bg-white rounded-xl overflow-hidden tablet:inline-flex desktop:hidden flex-col">
           <div className="self-stretch inline-flex justify-start items-center h-[121px] gap-2 my-2">
             <div className="relative w-64 h-32">
               <div

--- a/src/components/shared/Filters.tsx
+++ b/src/components/shared/Filters.tsx
@@ -28,7 +28,7 @@ const baseTypography =
  */
 const pillLayout =
   `inline-flex min-h-[42px] justify-center items-center gap-[10px] rounded-[10px] px-[18px] py-3 desktop:h-[42px] desktop:min-h-0 desktop:px-[30px] desktop:py-[10px] 
-    hover:bg-blueprint-lightGrey hover:border-blueprint-grey`;
+    hover:bg-bp-light-grey hover:border-bp-grey`;
 
 function Filters(props: FiltersProps) {
   if (props.variant === "light") {
@@ -43,8 +43,8 @@ function Filters(props: FiltersProps) {
           baseTypography,
           "border",
           isSelected
-            ? "border-blueprint-accent-lightBlue bg-blueprint-accent-veryLightBlue text-blueprint-black"
-            : "border-blueprint-filterOnWhite-border bg-blueprint-filterOnWhite-bgDefault text-blueprint-black",
+            ? "border-bp-accent-light-blue bg-bp-accent-very-light-blue text-bp-black"
+            : "border-bp-grey bg-bp-light-grey/30 text-bp-black",
           className,
         ]
           .filter(Boolean)
@@ -64,9 +64,9 @@ function Filters(props: FiltersProps) {
       className={[
         pillLayout,
         baseTypography,
-        state === "outlined"
-          ? "border border-blueprint-white bg-blueprint-white/20 text-blueprint-white"
-          : "border border-transparent bg-blueprint-white text-blueprint-neutral-dark",
+          state === "outlined"
+          ? "border border-bp-white bg-bp-white/20 text-bp-white"
+          : "border border-transparent bg-bp-white text-bp-black",
         className,
       ]
         .filter(Boolean)

--- a/src/components/shared/MemberCard.tsx
+++ b/src/components/shared/MemberCard.tsx
@@ -15,11 +15,11 @@ export type MemberCardProps = {
 
 // Role-based hover/click background (solid brand colors per palette)
 const ROLE_HOVER_BG_CLASS: Record<NonNullable<MemberCardProps["roleType"]>, string> = {
-  designer: "bg-blueprint-accent-purple",
-  pm: "bg-blueprint-orange",
-  dev: "bg-blueprint-accent-lightBlue",
-  exec: "bg-blueprint-accent-veryLightBlue",
-  techLead: "bg-blueprint-accent-mediumBlue",
+  designer: "bg-bp-accent-purple",
+  pm: "bg-bp-orange",
+  dev: "bg-bp-accent-light-blue",
+  exec: "bg-bp-accent-very-light-blue",
+  techLead: "bg-bp-accent-medium-blue",
 };
 // [#71EC59]
 const BORDER_RADIUS = 10;
@@ -48,7 +48,7 @@ export default function MemberCard({
     <div className="flex flex-col items-start w-full flex-1 min-h-0">
       {/* Photo placeholder or image: phone 153×127; tablet/desktop full width, aspect-square */}
       <div
-        className="w-min-[153px] h-[127px] w-full tablet:aspect-square tablet:max-h-[180px] tablet:h-auto tablet:min-h-[120px] rounded-md bg-blueprint-gray-lightest overflow-hidden shrink-0"
+        className="w-min-[153px] h-[127px] w-full tablet:aspect-square tablet:max-h-[180px] tablet:h-auto tablet:min-h-[120px] rounded-md bg-bp-lightest-grey overflow-hidden shrink-0"
       >
         {photoUrl ? (
           <img
@@ -57,7 +57,7 @@ export default function MemberCard({
             className="w-full h-full object-cover"
           />
         ) : (
-          <div className="w-full h-full bg-blueprint-grey" aria-hidden />
+          <div className="w-full h-full bg-bp-grey" aria-hidden />
         )}
       </div>
 

--- a/src/components/shared/NavigationTabs.tsx
+++ b/src/components/shared/NavigationTabs.tsx
@@ -32,7 +32,7 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
     <nav className="w-full font-poppins" aria-label="Section navigation">
       <div
         ref={containerRef}
-        className="relative flex flex-nowrap gap-x-6 overflow-x-auto border-b border-blueprint-neutral-mutedAlt [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+        className="relative flex flex-nowrap gap-x-6 overflow-x-auto border-b border-bp-grey [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
       >
         {tabs.map((tab, i) => {
           const isActive = activeHref != null && tab.href === activeHref;
@@ -41,7 +41,7 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
               key={tab.href}
               to={tab.href}
               className={`group relative inline-flex shrink-0 w-fit max-w-fit py-3 px-4 text-sm leading-[100%] tracking-normal whitespace-nowrap transition-colors duration-150 ${
-                isActive ? "text-blueprint-linkHover" : "text-blueprint-neutral-dark"
+                isActive ? "text-bp-blue" : "text-bp-black"
               }`}
               aria-current={isActive ? "page" : undefined}
             >
@@ -65,7 +65,7 @@ export default function NavigationTabs({ tabs, activeHref }: NavigationTabsProps
         })}
         {activeIndex >= 0 && (
           <span
-            className="absolute left-0 bottom-0 -mb-px h-[4px] bg-blueprint-linkHover rounded-t-full shadow-[0_2px_4px_rgba(0,0,0,0.1)] transition-all duration-150 ease-out"
+            className="absolute left-0 bottom-0 -mb-px h-[4px] bg-bp-blue rounded-t-full shadow-[0_2px_4px_rgba(0,0,0,0.1)] transition-all duration-150 ease-out"
             style={{ left: underlineLeft, width: underlineWidth }}
             aria-hidden
           />

--- a/src/components/shared/OpenRoleCard.tsx
+++ b/src/components/shared/OpenRoleCard.tsx
@@ -88,7 +88,7 @@ export default function OpenRoleCard({
     "w-full min-w-0 flex items-center rounded-[10px] border-2 transition-colors duration-150 font-poppins cursor-pointer",
     "min-[520px]:flex-1 min-[520px]:h-[100px] min-[520px]:justify-between",
     "p-6 pl-4 gap-3 min-[520px]:py-[30px] min-[520px]:px-9 min-[520px]:gap-0",
-    usePressedFill ? "bg-black" : "bg-blueprint-darkestGrey",
+    usePressedFill ? "bg-black" : "bg-bp-darkest-grey",
     showAccentBorder ? "" : "border-transparent",
   ].join(" ");
 

--- a/src/components/shared/OutlineButton.jsx
+++ b/src/components/shared/OutlineButton.jsx
@@ -16,7 +16,7 @@ const OutlineButton = (
 ) => {
     return (
       <button
-        className={`${className} btn flex-nowrap hover:bg-blueprint-blue hover:text-white text-blueprint-blue outline-blueprint-blue p-4 rounded-md border-2 font-poppins font-bold tracking-tight
+        className={`${className} btn flex-nowrap hover:bg-bp-blue hover:text-white text-bp-blue outline-bp-blue p-4 rounded-md border-2 font-poppins font-bold tracking-tight
         sm:w-[50] md:w-200 md:min-w-[200px] `}
         onClick={onClick}
       >

--- a/src/components/shared/PolaroidPhoto.tsx
+++ b/src/components/shared/PolaroidPhoto.tsx
@@ -19,7 +19,7 @@ type PolaroidPhotoProps = {
 const PolaroidPhoto = ({imageSrc, caption, alt, className = ""}: PolaroidPhotoProps) => {
     // Outer container for component
     return (
-    <div className={`bg-blueprint-white gap-[8px] shadow-[2px_4px_10px_0px_rgba(0,0,0,0.07)] w-[306px] h-[270px] pt-[11px] pr-[12px] pb-[15px] pl-[13px] 
+    <div className={`bg-bp-white gap-[8px] shadow-[2px_4px_10px_0px_rgba(0,0,0,0.07)] w-[306px] h-[270px] pt-[11px] pr-[12px] pb-[15px] pl-[13px] 
                     md:h-[345px] md:w-[377px] md:px-[18px] md:pt[20px] md:pb[24px] overflow-hidden ${className}`}>
         {/* Inner container for all elements */}
         <div className="flex flex-col self-stretch shrink-0 items-center gap-[8px] md:gap-[10px]"> 
@@ -27,7 +27,7 @@ const PolaroidPhoto = ({imageSrc, caption, alt, className = ""}: PolaroidPhotoPr
             <div className="h-[206px] overflow-hidden md:h-[267px]">
                 <img className="object-cover object-top w-full h-full block" src={imageSrc} alt={alt}/>
             </div>
-            <p className="decoration-blueprint-black text-center font-caveat text-[24px] md:text-3xl text-wrap">{caption}</p>
+            <p className="decoration-bp-black text-center font-caveat text-[24px] md:text-3xl text-wrap">{caption}</p>
         </div>  
     </div>
     );

--- a/src/components/shared/ProjectsCTA.tsx
+++ b/src/components/shared/ProjectsCTA.tsx
@@ -8,7 +8,7 @@ const ProjectsCTA = () => {
     return (
         <>
         {/* Container */}
-        <div className="w-90 pl-6 pr-3 py-3 bg-blueprint-navyblue rounded-[5px]
+        <div className="w-90 pl-6 pr-3 py-3 bg-bp-blue rounded-[5px]
         shadow-[0px_4px_7px_0px_rgba(0,0,0,0.07)] inline-flex flex-row justify-between items-center gap-2.5 flex-shrink-0
         md:w-[460px] md:pl-9 md:pr-3 md:py-3">
             {/* Text Container */}
@@ -18,7 +18,7 @@ const ProjectsCTA = () => {
                     Launch a project for your non profit!
                 </p>
                 <Link to="/nonprofits" className="flex-shrink-0 w-36 h-[52px] bg-white rounded-[5px]
-                                    inline-flex justify-center items-center text-blueprint-navyblue text-sm font-semibold  
+                                    inline-flex justify-center items-center text-bp-blue text-sm font-semibold  
                                     font-poppins hover:bg-gray-100 transition-colors
                                     md:w-48 md:h-14 md:text-base">
                     LEARN MORE

--- a/src/components/shared/SocialMediaLinkCard.tsx
+++ b/src/components/shared/SocialMediaLinkCard.tsx
@@ -79,16 +79,16 @@ export default function SocialMediaLinkCard({
             <span className="shrink-0 flex items-center justify-center w-[20px] h-[20px] tablet:w-[30px] tablet:h-[30px]" aria-hidden>
               {icon}
             </span>
-            <span className="font-poppins font-normal text-blueprint-black text-[24px] leading-[1.4] tracking-[-0.48px] 
+            <span className="font-poppins font-normal text-bp-black text-[24px] leading-[1.4] tracking-[-0.48px] 
                             tablet:text-heading-xs-reg tablet:leading-[1.4] tablet:tracking-[-0.72px] whitespace-nowrap">
               {platform}
             </span>
           </div>
-          <ArrowUpRight className="shrink-0 text-blueprint-black w-[35px] h-[35px] tablet:w-[46px] tablet:h-[46px]" />
+          <ArrowUpRight className="shrink-0 text-bp-black w-[35px] h-[35px] tablet:w-[46px] tablet:h-[46px]" />
         </div>
 
         {/* Description */}
-        <p className="font-poppins font-normal text-blueprint-black text-[14px] tablet:text-[16px] leading-normal m-0 tablet:max-w-[400px]">
+        <p className="font-poppins font-normal text-bp-black text-[14px] tablet:text-[16px] leading-normal m-0 tablet:max-w-[400px]">
           {description}
         </p>
       </div>

--- a/src/components/shared/StickyCTA.tsx
+++ b/src/components/shared/StickyCTA.tsx
@@ -14,7 +14,7 @@ const StickyCTA = () => {
         <div className="ml-auto mr-auto sticky h-0 bottom-[0px]
                         min-[509px]:w-[460px]
                         max-[508px]:w-[100%]">
-            <div className="h-[84px] z-20 bg-blueprint-navyblue py-[12px] pl-[36px] pr-[12px] rounded-[8px] shadow-[2px_4px_10px_0_rgba(0_0_0_0.07)] overflow-hidden absolute
+            <div className="h-[84px] z-20 bg-bp-blue py-[12px] pl-[36px] pr-[12px] rounded-[8px] shadow-[2px_4px_10px_0_rgba(0_0_0_0.07)] overflow-hidden absolute
                              min-[509px]:translate-y-[-162px]
                              max-[508px]:pl-[24px] max-[508px]:rounded-[5px] max-[508px]:translate-y-[-132px]">
                 {/* Content Flex Row Container */}
@@ -22,12 +22,12 @@ const StickyCTA = () => {
                                 min-[509px]:justify-between min-[509px]:gap-auto 
                                 max-[508px]:gap-[36px]">
                     {/* Text */}
-                    <p className="font-poppins text-[16px] text-blueprint-white
+                    <p className="font-poppins text-[16px] text-bp-white
                                 max-[508px]:text-[14px] max-[508px]:grow-1 ">
                                     Launch a project for your non profit!
                     </p>
                     {/* BTN */}
-                    <Button variant="secondary" children={`LEARN MORE`} className="w-[200px] h-[60px] max-[508px]:grow-1 text-blueprint-navyblue"/>
+                    <Button variant="secondary" children={`LEARN MORE`} className="w-[200px] h-[60px] max-[508px]:grow-1 text-bp-blue"/>
 
                 </div>
             </div>

--- a/src/pages/AlumniPage.tsx
+++ b/src/pages/AlumniPage.tsx
@@ -79,13 +79,13 @@ const AlumniPage = () => {
   const memberData: memberCardData[] = getMemberData();
 
   return (
-  <PageContainer className="bg-blueprint-gray-lightest items-center flex-col flex">
+  <PageContainer className="bg-bp-lightest-grey items-center flex-col flex">
     {/* Hero Section */}
     <section className="flex items-center flex-col tablet:mt-[39px] tablet:mb-[69px] mt-[31px] mb-[44px]">
       <h1 className="decoration-[#2E2E2E] font-poppins text-center mb-[30px] tablet:text-heading-m-reg text-heading-m-reg-mobile">
         thank you, sfu blueprint alumni!
       </h1>
-      <p className="font-caveat  text-center max-w-[786px] tablet:decoration-blueprint-black tablet:mb-[81px] mb-[61px] tablet:text-heading-hand text-mobile-heading-hand decoration-black">
+      <p className="font-caveat  text-center max-w-[786px] tablet:decoration-bp-black tablet:mb-[81px] mb-[61px] tablet:text-heading-hand text-mobile-heading-hand decoration-black">
         The impact you've created, for our projects and our community, continues to define who we are as a team.
       </p>
       {/* Filter buttons */}

--- a/src/pages/NonprofitsPage.tsx
+++ b/src/pages/NonprofitsPage.tsx
@@ -10,89 +10,88 @@ const NonprofitsPage = () => {
 
   return (
     <PageContainer
-      className="bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat 
-                              min-[1280px]:bg-[calc(100%+585px)_-500px]
-                              max-[1279px]:bg-[calc(100%+689px)_-500px]
-                              max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_-132px]"
+      className="!pt-[148px] lg:!pt-[132px] overflow-x-hidden bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat
+                              min-[1280px]:bg-[calc(100%+585px)_-360px]
+                              max-[1279px]:bg-[calc(100%+689px)_-360px]
+                              max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_14.5px]"
     >
       {/* Hero Section */}
       <section
         className="mb-[180px]
                         max-[1024px]:mb-[30px]"
       >
-        <h1
-          className="text-blueprint-neutral-dark text-[96px]/[100%] font-[400] font-poppins tracking-[-1.92px] text-left mb-[24px] whitespace-pre-wrap
-                        max-md:text-[56px] max-md:tracking-[-1.12px] max-md:mb-[12px]
-                        max-[400px]:w-[200px]"
-        >
-          <strong>partner</strong> with us
-        </h1>
-
-        {/* Img & Desc container*/}
+        {/* 939px text column; polaroid nudged from Figma 781.74 baseline (md:-ml / md:mt fine-tuned) */}
         <div
-          className="flex flex-row w-[100%] 
-                        max-[900px]:flex-col"
+          className="flex w-full flex-row gap-0 max-[900px]:flex-col max-[900px]:gap-8"
         >
-          <p
-            className="font-poppins font-[400] text-[30px]/[100%] text-black tracking-[-0.6px] 
-                        min-[769px]:pr-[30px]
-                        max-md:text-[20px]/[140%] max-md:text-blueprint-neutral-dark max-md:tracking-[-0.4px]"
-          >
-            by working with us, your organization will{" "}
-            <span className={`bg-blueprint-orange ${colouredRectCSSBase}`} /> gain fresh
-            perspectives of your business,{" "}
-            <span className={`bg-[#71EC59] ${colouredRectCSSBase}`} /> increase community
-            engagement with local students, and{" "}
-            <span className={`bg-[#D2A6FB] ${colouredRectCSSBase}`} /> bring your vision
-            for social good to life through innovative ways, all free of charge.
-          </p>
+          <div className="flex min-w-0 w-full max-w-full flex-col md:max-w-[939px] md:w-[939px] md:shrink-0">
+            <h1
+              className="m-0 whitespace-pre-wrap text-left font-poppins text-blueprint-black text-[72px] tracking-[-1.44px] leading-none mb-[24px]
+                        max-md:max-w-[233px] max-md:text-[46px] max-md:tracking-[-0.92px] max-md:leading-none max-md:mb-[12px]
+                        md:max-w-none"
+            >
+              <span className="font-bold leading-[1] max-md:leading-none">partner</span>{" "}
+              <span className="font-normal leading-[normal] max-md:font-normal max-md:leading-none">
+                with us
+              </span>
+            </h1>
 
-          {/* Polaroid Wrapper */}
+            <p
+              className="m-0 max-w-[693.5px] min-w-0 self-stretch font-poppins text-black text-heading-xs-reg
+                        max-md:max-w-[351px] max-md:text-blueprint-black max-md:text-mobile-heading-xs-reg"
+            >
+              by working with us, your organization will{" "}
+              <span className={`bg-[#D2A6FB] ${colouredRectCSSBase}`} /> gain fresh
+              perspectives of your business,{" "}
+              <span className={`bg-[#71EC59] ${colouredRectCSSBase}`} /> increase community
+              engagement with local students, and{" "}
+              <span className={`bg-[#F49F00] ${colouredRectCSSBase}`} /> bring your
+              vision for social good to life through innovative ways, all free of charge.
+            </p>
+          </div>
+
           <div
-            className="min-[1025px]:h-0
-                          max-[1024px]:mt-[32px]"
+            className="min-w-0 shrink-0 min-[1025px]:h-0 md:-ml-[72px] md:mt-[108px] max-[900px]:ml-0 max-[900px]:mt-[20px]"
           >
             <PolaroidPhoto
               imageSrc="https://placehold.co/398x298"
               caption="placeholder"
               alt="placeholder"
-              className="ml-auto rotate-[7deg]
-                       max-[1024px]:mr-auto "
+              className="rotate-[7deg] max-[1024px]:mx-auto"
             />
           </div>
         </div>
       </section>
 
       {/* Project Trait and BP approach grouping */}
-      <section className="mb-[80px]">
+      <section className="mb-[120px] max-md:mb-[80px]">
         {/* Project Traits Section*/}
         <section
-          className="mb-[60px]
-                          max-md:mb-[18px]"
+          className="mb-[148px] max-md:mb-[80px]"
         >
-          <div className="flex flex-col gap-[6px] mb-[30px]">
+          <div className="flex flex-col gap-3 mb-12 max-md:mb-10">
             <h2
-              className="text-blueprint-neutral-dark font-poppins font-[600] text-[36px]/[140%] tracking-[-0.72px]
-                          max-md:text-[24px]/[110%] max-md:tracking-[-0.48px] max-md:mb-[12px]"
+              className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
+                          max-md:max-w-[253px] max-md:text-blueprint-black max-md:text-mobile-heading-s-bold max-md:mb-[12px]"
             >
-              can your idea become a project?
+              can <span className="md:font-semibold">your idea</span> become a project?
             </h2>
             <p
               className="text-black font-poppins text-[24px]/[130%] font-[400] tracking-[-0.48px]
-                        max-md:text-[18px] max-md:tracking-[-0.36px]"
+                        max-md:max-w-[305px] max-md:text-mobile-body-l-reg"
             >
-              We consider the following aspects when evaluating potential projects.
+              We consider the following aspects when evaluating potential projects:
             </p>
           </div>
 
           {/* Eval Card list */}
           <ul
-            className="flex flex-row gap-x-[6px] max-w-[100%]
-                       max-[1076px]:flex-col max-[1076px]:gap-y-[18px]"
+            className="flex flex-row gap-x-6 max-w-[100%]
+                       max-[1076px]:flex-col max-[1076px]:gap-y-6"
           >
             <li>
               <EvaluationCard
-                colour="blueprint-navyblue"
+                colour="blueprint-blue"
                 title="Organizational Need"
                 body="What measurable improvements would this product deliver to current operations? 
             How does it align with long-term organizational goals? How urgent is its development?"
@@ -100,16 +99,16 @@ const NonprofitsPage = () => {
             </li>
             <li>
               <EvaluationCard
-                colour="blueprint-orange"
+                colour="blueprint-accent-purple"
                 title="Technical Feasibility"
                 body="Are the desired features commonly found in other software products? Example solutions include mobile apps, websites, browser-based games, databases, and AI/ML systems."
               />
             </li>
             <li>
               <EvaluationCard
-                colour="blueprint-blue"
+                colour="blueprint-accent-mediumBlue"
                 title="Community Impact"
-                body="Does the non-profit understand the challenges encountered by the community it serves? How would the product would align with solving those problems?"
+                body="Does the non-profit understand the challenges encountered by the community it serves? How would the product align with solving those problems?"
               />
             </li>
           </ul>
@@ -118,13 +117,13 @@ const NonprofitsPage = () => {
         {/* BP Approach Section */}
         <section>
           <h2
-            className="text-blueprint-neutral-dark font-poppins font-[600] text-[36px]/[140%] tracking-[-0.72px] mb-[24px]
+            className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px] mb-12
                         max-md:text-[24px]/[110%] max-md:tracking-[-0.48px] max-md:mb-[18px]"
           >
-            our approach
+            our <span className="font-semibold">approach</span>
           </h2>
 
-          <div className="flex flex-col gap-[16px] max-md:gap-[12px]">
+          <div className="flex flex-col gap-4 max-md:gap-3">
             <Accordion header="01. Discover">
               <div className="flex flex-col gap-[24px] md:gap-[30px]">
                 <div className="flex flex-col gap-[6px]">
@@ -206,21 +205,17 @@ const NonprofitsPage = () => {
         </section>
       </section>
 
-      {/* What our partners say */}
-      <section
-        className="m-4 mb-[60px]
-                        max-md:mb-[40px]"
-      >
+      {/* What our partners say ΓÇö hidden on mobile per design */}
+      <section className="mb-0 max-md:hidden">
         <h2
-          className="text-blueprint-neutral-dark font-poppins font-[600] text-[36px]/[140%] tracking-[-0.72px]
+          className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
                       max-md:text-[24px]/[110%] max-md:tracking-[-0.48px]"
         >
-          what our partners say
+          what <span className="font-semibold">our partners</span> say
         </h2>
 
         <p
-          className="text-black font-caveat font-[400] text-[34px]/[100%] mt-[24px] mb-[24px]
-                    max-md:text-[24px]/[120%] max-md:mt-[18px] max-md:mb-[18px]"
+          className="m-0 mt-12 max-w-[1160px] w-full min-w-0 self-stretch text-blueprint-black font-caveat text-heading-hand leading-[140%] mb-9"
         >
           [The work SFU Blueprint has done] is much appreciated and there is a lot
           of thanks that cannot really be simply put into words... Volunteers at OCB
@@ -231,63 +226,79 @@ const NonprofitsPage = () => {
           it will allow us to manage it better and more efficiently.
         </p>
 
-        <div>
-          <p className="text-black font-poppins font-[400] text-[14px]/[100%] uppercase">
+        <div className="max-w-[241px] w-full min-w-0 self-stretch">
+          <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
             CAVAN HUA
           </p>
-          <p className="text-black font-poppins font-[400] text-[14px]/[100%] uppercase mt-[2px]">
+          <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
             VOLUNTEER COORDINATOR AT OCB
           </p>
         </div>
       </section>
 
-      {/* NPO project proposal - full viewport width, breaks out of PageContainer padding */}
+      {/* NPO project proposal ΓÇö mobile: full-bleed bp-blue, white type, white CTA; md+: gray card (Figma) */}
       <section
-        className="-mx-6 bg-blueprint-navyblue overflow-hidden px-6 pt-[45px] pb-[68px] pl-[23px] pr-[21px] flex min-w-96 
-                sm:mx-10% sm:px-[103px] sm:pt-[60px] sm:pb-[80px] sm:rounded-2xl sm:mb-[52px]"
+        className="mt-[148px] max-md:mt-16 mb-12 md:mb-16
+                -mx-6 min-w-0 md:-mx-10 xl:-mx-36
+                max-md:bg-blueprint-blue max-md:py-12 max-md:!px-6
+                px-3 sm:px-4 md:px-5 xl:px-6 md:bg-transparent"
       >
-        <div className="flex flex-col justify-start items-start gap-6 sm:gap-12 w-full">
-          <h2
-            className="w-full text-white text-3xl font-light font-poppins leading-8
-            sm:text-heading-m-reg sm:leading-[57.60px] lg:max-w-[655px]"
-          >
-            are you part of an NPO with a project idea in mind?
-          </h2>
-
-          <div className="self-stretch h-px bg-white scale-y-[0.5] origin-center" />
-
-          <div
-            className="flex flex-col justify-start items-start gap-3 w-full 
-          sm:flex-row sm:justify-between sm:items-start sm:gap-6 lg:justify-between"
-          >
-            <div className="flex flex-col justify-start items-start gap-6 w-full sm:max-w-[588px] max-sm:mb-10">
-              <p
-                className="text-white text-lg font-normal font-poppins leading-6 pr-24
-               sm:self-stretch sm:text-2xl sm:font-normal sm:leading-8 sm:pr-0 sm:gap-6"
+        <div
+          className="w-full box-border shrink-0 flex flex-col justify-center items-stretch
+                max-md:bg-transparent max-md:p-0 max-md:min-h-0
+                bg-blueprint-npoSection rounded-[20px]
+                pt-[72px] pb-[96px] px-6 sm:px-10 md:px-[103px]
+                md:min-h-[560px]"
+        >
+          <div className="flex flex-col w-full max-w-[931px] mx-auto justify-center items-stretch">
+            <div className="mb-8 flex w-full items-start gap-[26px] max-md:mb-10 md:mb-12 max-md:gap-0">
+              <span
+                className="mt-4 hidden shrink-0 w-[22px] h-[22px] rounded-[5px] bg-blueprint-blue md:block"
+                aria-hidden
+              />
+              <h2
+                className="m-0 min-h-0 w-full min-w-0 max-md:max-w-[280px] text-left font-poppins text-white text-mobile-heading-m-reg md:max-w-[483px] md:font-normal md:text-blueprint-black md:text-heading-s-reg"
               >
-                Submit your project proposal through the form!
-              </p>
-              <p className="text-white text-base font-light font-poppins leading-6 max-w-100% max-h-100%">
-                If you have any questions, or haven&apos;t heard back from us within a
-                week of submitting a proposal, feel free to reach out to{" "}
-                <a
-                  href="mailto:sfublueprint@gmail.com"
-                  className="text-white font-normal underline hover:opacity-90"
-                >
-                  sfublueprint@gmail.com
-                </a>
-              </p>
+                are you part of an NPO with{" "}
+                <span className="font-normal md:font-semibold">a project idea</span> in mind?
+              </h2>
             </div>
 
-            <a
-              href="/nonprofits/proposal"
-              className="w-full h-[52px] px-11 py-3.5 bg-white rounded-[5px] flex flex-row justify-center items-center 
-              gap-2.5 hover:bg-blueprint-offwhite transition-colors flex-shrink-0 sm:w-[200px] sm:h-[60px]"
-            >
-              <span className="text-blue-800 text-sm sm:text-base font-semibold font-poppins whitespace-nowrap">
-                PROPOSAL FORM
-              </span>
-            </a>
+            <div
+              className="mb-8 h-[0.5px] w-full min-w-0 shrink-0 self-stretch bg-white/35 max-md:mb-10 md:mb-12 md:max-w-[931px] md:bg-blueprint-grey"
+              aria-hidden
+            />
+
+            <div className="flex w-full flex-col md:flex-row md:items-start md:justify-between md:gap-12 max-md:gap-0">
+              <div className="flex w-full max-w-full min-w-0 flex-col gap-6 self-start md:w-[588px] md:max-w-[588px] md:shrink-0">
+                <div className="w-full min-w-0 self-stretch overflow-x-auto sm:overflow-visible max-md:max-w-[253px] max-md:overflow-visible md:max-w-none">
+                  <p className="text-left font-poppins whitespace-normal text-mobile-body-l-bold text-blueprint-white md:whitespace-nowrap md:text-body-l-bold md:text-blueprint-black">
+                    Submit your project proposal through the form!
+                  </p>
+                </div>
+                <p className="w-full min-w-0 max-w-full self-stretch text-left font-poppins leading-[normal] text-body-m-reg text-blueprint-white max-md:max-w-[346px] max-md:flex-1 max-md:basis-0 max-md:shrink-0 md:max-w-none md:flex-none md:basis-auto md:text-blueprint-black">
+                  If you have any questions, or haven&apos;t heard back from us within a
+                  week of submitting a proposal, feel free to reach out to{" "}
+                  <a
+                    href="mailto:sfublueprint@gmail.com"
+                    className="font-poppins text-body-m-bold-link leading-[normal] text-blueprint-white underline decoration-solid [text-decoration-skip-ink:auto] underline-offset-auto hover:opacity-90 md:text-body-m-bold-link md:text-blueprint-black md:hover:opacity-80"
+                  >
+                    sfublueprint@gmail.com
+                  </a>
+                </p>
+              </div>
+
+              <a
+                href="/nonprofits/proposal"
+                className="inline-flex w-full shrink-0 items-center justify-center gap-[10px] rounded-[5px] transition-colors
+                max-md:mt-10 max-md:min-h-[52px] max-md:px-6 max-md:py-3.5 max-md:bg-white max-md:hover:bg-blueprint-offwhite
+                md:mt-0 md:box-border md:h-[60px] md:w-[200px] md:max-w-full md:self-start md:px-[44px] md:py-[14px] md:bg-blueprint-black md:hover:bg-blueprint-darkestGrey"
+              >
+                <span className="whitespace-nowrap text-center font-poppins uppercase leading-[normal] text-mobile-body-m-bold text-blueprint-blue md:text-body-m-bold md:text-blueprint-white">
+                  PROPOSAL FORM
+                </span>
+              </a>
+            </div>
           </div>
         </div>
       </section>

--- a/src/pages/NonprofitsPage.tsx
+++ b/src/pages/NonprofitsPage.tsx
@@ -10,7 +10,7 @@ const NonprofitsPage = () => {
 
   return (
     <PageContainer
-      className="!pt-[148px] lg:!pt-[132px] overflow-x-hidden bg-blueprint-gray-lightest bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat
+      className="!pt-[148px] lg:!pt-[132px] overflow-x-hidden bg-bp-lightest-grey bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat
                               min-[1280px]:bg-[calc(100%+585px)_-360px]
                               max-[1279px]:bg-[calc(100%+689px)_-360px]
                               max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_14.5px]"
@@ -28,7 +28,7 @@ const NonprofitsPage = () => {
             className="flex min-w-0 w-full max-w-full flex-col md:shrink-0 md:max-w-[min(100%,calc(100vw*939/1422))] md:w-[min(100%,calc(100vw*939/1422))]"
           >
             <h1
-              className="m-0 whitespace-pre-wrap text-left font-poppins text-blueprint-black text-[72px] tracking-[-1.44px] leading-none mb-[24px]
+              className="m-0 whitespace-pre-wrap text-left font-poppins text-bp-black text-[72px] tracking-[-1.44px] leading-none mb-[24px]
                         max-md:max-w-[233px] max-md:text-[46px] max-md:tracking-[-0.92px] max-md:leading-none max-md:mb-[12px]
                         md:max-w-none"
             >
@@ -40,7 +40,7 @@ const NonprofitsPage = () => {
 
             <p
               className="m-0 min-w-0 self-stretch font-poppins text-black text-heading-xs-reg
-                        max-md:max-w-[351px] max-md:text-blueprint-black max-md:text-mobile-heading-xs-reg
+                        max-md:max-w-[351px] max-md:text-bp-black max-md:text-mobile-heading-xs-reg
                         md:max-w-[min(100%,calc(100vw*693.5/1422))]"
             >
               by working with us, your organization will{" "}
@@ -74,8 +74,8 @@ const NonprofitsPage = () => {
         >
           <div className="flex flex-col gap-3 mb-12 max-md:mb-10">
             <h2
-              className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
-                          max-md:max-w-[253px] max-md:text-blueprint-black max-md:text-mobile-heading-s-bold max-md:mb-[12px]"
+              className="text-bp-black font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
+                          max-md:max-w-[253px] max-md:text-bp-black max-md:text-mobile-heading-s-bold max-md:mb-[12px]"
             >
               can <span className="md:font-semibold">your idea</span> become a project?
             </h2>
@@ -94,7 +94,7 @@ const NonprofitsPage = () => {
           >
             <li>
               <EvaluationCard
-                colour="blueprint-blue"
+                colour="bp-blue"
                 title="Organizational Need"
                 body="What measurable improvements would this product deliver to current operations? 
             How does it align with long-term organizational goals? How urgent is its development?"
@@ -102,14 +102,14 @@ const NonprofitsPage = () => {
             </li>
             <li>
               <EvaluationCard
-                colour="blueprint-accent-purple"
+                colour="bp-accent-purple"
                 title="Technical Feasibility"
                 body="Are the desired features commonly found in other software products? Example solutions include mobile apps, websites, browser-based games, databases, and AI/ML systems."
               />
             </li>
             <li>
               <EvaluationCard
-                colour="blueprint-accent-mediumBlue"
+                colour="bp-accent-medium-blue"
                 title="Community Impact"
                 body="Does the non-profit understand the challenges encountered by the community it serves? How would the product align with solving those problems?"
               />
@@ -120,7 +120,7 @@ const NonprofitsPage = () => {
         {/* BP Approach Section */}
         <section>
           <h2
-            className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px] mb-12
+            className="text-bp-black font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px] mb-12
                         max-md:text-[24px]/[110%] max-md:tracking-[-0.48px] max-md:mb-[18px]"
           >
             our <span className="font-semibold">approach</span>
@@ -212,14 +212,14 @@ const NonprofitsPage = () => {
       <section className="mb-0 max-md:hidden">
         <div className="w-full min-w-0 max-w-[min(100%,calc(100vw*1160/1422))]">
           <h2
-            className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
+            className="text-bp-black font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
                         max-md:text-[24px]/[110%] max-md:tracking-[-0.48px]"
           >
             what <span className="font-semibold">our partners</span> say
           </h2>
 
           <p
-            className="m-0 mt-12 w-full min-w-0 text-blueprint-black font-caveat text-heading-hand leading-[140%] mb-9"
+            className="m-0 mt-12 w-full min-w-0 text-bp-black font-caveat text-heading-hand leading-[140%] mb-9"
           >
             [The work SFU Blueprint has done] is much appreciated and there is a lot
             of thanks that cannot really be simply put into words... Volunteers at OCB
@@ -231,10 +231,10 @@ const NonprofitsPage = () => {
           </p>
 
           <div className="w-full min-w-0 max-w-[min(100%,calc(100vw*241/1422))]">
-            <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
+            <p className="m-0 text-bp-black font-poppins text-body-s-reg uppercase">
               CAVAN HUA
             </p>
-            <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
+            <p className="m-0 text-bp-black font-poppins text-body-s-reg uppercase">
               VOLUNTEER COORDINATOR AT OCB
             </p>
           </div>
@@ -245,24 +245,24 @@ const NonprofitsPage = () => {
       <section
         className="mt-[148px] max-md:mt-16 mb-12 md:mb-16
                 -mx-6 min-w-0 md:-mx-10 xl:-mx-36
-                max-md:bg-blueprint-navyblue max-md:py-12 max-md:!px-6
+                max-md:bg-bp-blue max-md:py-12 max-md:!px-6
                 px-3 sm:px-4 md:px-5 xl:px-6 md:bg-transparent"
       >
         <div
           className="w-full box-border shrink-0 flex flex-col justify-center items-stretch
                 max-md:bg-transparent max-md:p-0 max-md:min-h-0
-                md:bg-blueprint-gray-neutral rounded-[20px]
+                md:bg-bp-lighter-grey rounded-[20px]
                 pt-[72px] pb-[96px] px-6 sm:px-10 md:px-[103px]
                 md:min-h-[560px]"
         >
           <div className="flex flex-col w-full max-w-[931px] mx-auto justify-center items-stretch">
             <div className="mb-8 flex w-full items-start gap-[26px] max-md:mb-10 md:mb-12 max-md:gap-0">
               <span
-                className="mt-4 hidden shrink-0 w-[22px] h-[22px] rounded-[5px] bg-blueprint-navyblue md:block"
+                className="mt-4 hidden shrink-0 w-[22px] h-[22px] rounded-[5px] bg-bp-blue md:block"
                 aria-hidden
               />
               <h2
-                className="m-0 min-h-0 w-full min-w-0 max-md:max-w-[280px] text-left font-poppins text-white text-mobile-heading-m-reg md:max-w-[483px] md:font-normal md:text-blueprint-black md:text-heading-s-reg"
+                className="m-0 min-h-0 w-full min-w-0 max-md:max-w-[280px] text-left font-poppins text-white text-mobile-heading-m-reg md:max-w-[483px] md:font-normal md:text-bp-black md:text-heading-s-reg"
               >
                 are you part of an NPO with{" "}
                 <span className="font-normal md:font-semibold">a project idea</span> in mind?
@@ -270,23 +270,23 @@ const NonprofitsPage = () => {
             </div>
 
             <div
-              className="mb-8 h-[0.5px] w-full min-w-0 shrink-0 self-stretch bg-white/35 max-md:mb-10 md:mb-12 md:max-w-[931px] md:bg-blueprint-grey"
+              className="mb-8 h-[0.5px] w-full min-w-0 shrink-0 self-stretch bg-white/35 max-md:mb-10 md:mb-12 md:max-w-[931px] md:bg-bp-grey"
               aria-hidden
             />
 
             <div className="flex w-full flex-col md:flex-row md:items-start md:justify-between md:gap-12 max-md:gap-0">
               <div className="flex w-full max-w-full min-w-0 flex-col gap-6 self-start md:w-[588px] md:max-w-[588px] md:shrink-0">
                 <div className="w-full min-w-0 self-stretch overflow-x-auto sm:overflow-visible max-md:max-w-[253px] max-md:overflow-visible md:max-w-none">
-                  <p className="text-left font-poppins whitespace-normal text-mobile-body-l-bold text-blueprint-white md:whitespace-nowrap md:text-body-l-bold md:text-blueprint-black">
+                  <p className="text-left font-poppins whitespace-normal text-mobile-body-l-bold text-bp-white md:whitespace-nowrap md:text-body-l-bold md:text-bp-black">
                     Submit your project proposal through the form!
                   </p>
                 </div>
-                <p className="w-full min-w-0 max-w-full self-stretch text-left font-poppins leading-[normal] text-body-m-reg text-blueprint-white max-md:max-w-[346px] max-md:flex-1 max-md:basis-0 max-md:shrink-0 md:max-w-none md:flex-none md:basis-auto md:text-blueprint-black">
+                <p className="w-full min-w-0 max-w-full self-stretch text-left font-poppins leading-[normal] text-body-m-reg text-bp-white max-md:max-w-[346px] max-md:flex-1 max-md:basis-0 max-md:shrink-0 md:max-w-none md:flex-none md:basis-auto md:text-bp-black">
                   If you have any questions, or haven&apos;t heard back from us within a
                   week of submitting a proposal, feel free to reach out to{" "}
                   <a
                     href="mailto:sfublueprint@gmail.com"
-                    className="font-poppins text-body-m-bold-link leading-[normal] text-blueprint-white underline decoration-solid [text-decoration-skip-ink:auto] underline-offset-auto hover:opacity-90 md:text-body-m-bold-link md:text-blueprint-black md:hover:opacity-80"
+                    className="font-poppins text-body-m-bold-link leading-[normal] text-bp-white underline decoration-solid [text-decoration-skip-ink:auto] underline-offset-auto hover:opacity-90 md:text-body-m-bold-link md:text-bp-black md:hover:opacity-80"
                   >
                     sfublueprint@gmail.com
                   </a>
@@ -296,10 +296,10 @@ const NonprofitsPage = () => {
               <a
                 href="/nonprofits/proposal"
                 className="inline-flex w-full shrink-0 items-center justify-center gap-[10px] rounded-[5px] transition-colors
-                max-md:mt-10 max-md:min-h-[52px] max-md:px-6 max-md:py-3.5 max-md:bg-white max-md:hover:bg-blueprint-offwhite
-                md:mt-0 md:box-border md:h-[60px] md:w-[200px] md:max-w-full md:self-start md:px-[44px] md:py-[14px] md:bg-blueprint-black md:hover:bg-blueprint-darkestGrey md:active:bg-blueprint-neutral-mid"
+                max-md:mt-10 max-md:min-h-[52px] max-md:px-6 max-md:py-3.5 max-md:bg-white max-md:hover:bg-bp-lightest-grey
+                md:mt-0 md:box-border md:h-[60px] md:w-[200px] md:max-w-full md:self-start md:px-[44px] md:py-[14px] md:bg-bp-black md:hover:bg-bp-darkest-grey md:active:bg-bp-dark-grey"
               >
-                <span className="whitespace-nowrap text-center font-poppins uppercase leading-[normal] text-mobile-body-m-bold text-blueprint-navyblue md:text-body-m-bold md:text-blueprint-white">
+                <span className="whitespace-nowrap text-center font-poppins uppercase leading-[normal] text-mobile-body-m-bold text-bp-blue md:text-body-m-bold md:text-bp-white">
                   PROPOSAL FORM
                 </span>
               </a>

--- a/src/pages/NonprofitsPage.tsx
+++ b/src/pages/NonprofitsPage.tsx
@@ -10,7 +10,7 @@ const NonprofitsPage = () => {
 
   return (
     <PageContainer
-      className="!pt-[148px] lg:!pt-[132px] overflow-x-hidden bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat
+      className="!pt-[148px] lg:!pt-[132px] overflow-x-hidden bg-blueprint-gray-lightest bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat
                               min-[1280px]:bg-[calc(100%+585px)_-360px]
                               max-[1279px]:bg-[calc(100%+689px)_-360px]
                               max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_14.5px]"
@@ -20,11 +20,13 @@ const NonprofitsPage = () => {
         className="mb-[180px]
                         max-[1024px]:mb-[30px]"
       >
-        {/* 939px text column; polaroid nudged from Figma 781.74 baseline (md:-ml / md:mt fine-tuned) */}
+        {/* Text column & body: width = viewport × (939|693.5)/1422; ref 1422px-wide screen */}
         <div
           className="flex w-full flex-row gap-0 max-[900px]:flex-col max-[900px]:gap-8"
         >
-          <div className="flex min-w-0 w-full max-w-full flex-col md:max-w-[939px] md:w-[939px] md:shrink-0">
+          <div
+            className="flex min-w-0 w-full max-w-full flex-col md:shrink-0 md:max-w-[min(100%,calc(100vw*939/1422))] md:w-[min(100%,calc(100vw*939/1422))]"
+          >
             <h1
               className="m-0 whitespace-pre-wrap text-left font-poppins text-blueprint-black text-[72px] tracking-[-1.44px] leading-none mb-[24px]
                         max-md:max-w-[233px] max-md:text-[46px] max-md:tracking-[-0.92px] max-md:leading-none max-md:mb-[12px]
@@ -37,8 +39,9 @@ const NonprofitsPage = () => {
             </h1>
 
             <p
-              className="m-0 max-w-[693.5px] min-w-0 self-stretch font-poppins text-black text-heading-xs-reg
-                        max-md:max-w-[351px] max-md:text-blueprint-black max-md:text-mobile-heading-xs-reg"
+              className="m-0 min-w-0 self-stretch font-poppins text-black text-heading-xs-reg
+                        max-md:max-w-[351px] max-md:text-blueprint-black max-md:text-mobile-heading-xs-reg
+                        md:max-w-[min(100%,calc(100vw*693.5/1422))]"
             >
               by working with us, your organization will{" "}
               <span className={`bg-[#D2A6FB] ${colouredRectCSSBase}`} /> gain fresh
@@ -51,7 +54,7 @@ const NonprofitsPage = () => {
           </div>
 
           <div
-            className="min-w-0 shrink-0 min-[1025px]:h-0 md:-ml-[72px] md:mt-[108px] max-[900px]:ml-0 max-[900px]:mt-[20px]"
+            className="min-w-0 shrink-0 min-[1025px]:h-0 md:-ml-[120px] md:mt-[108px] max-[900px]:ml-0 max-[900px]:mt-[20px]"
           >
             <PolaroidPhoto
               imageSrc="https://placehold.co/398x298"
@@ -205,55 +208,57 @@ const NonprofitsPage = () => {
         </section>
       </section>
 
-      {/* What our partners say ΓÇö hidden on mobile per design */}
+      {/* What our partners say — hidden on mobile; width ∝ viewport (1160px at 1422px ref) */}
       <section className="mb-0 max-md:hidden">
-        <h2
-          className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
-                      max-md:text-[24px]/[110%] max-md:tracking-[-0.48px]"
-        >
-          what <span className="font-semibold">our partners</span> say
-        </h2>
+        <div className="w-full min-w-0 max-w-[min(100%,calc(100vw*1160/1422))]">
+          <h2
+            className="text-blueprint-neutral-dark font-poppins font-normal text-[36px]/[140%] tracking-[-0.72px]
+                        max-md:text-[24px]/[110%] max-md:tracking-[-0.48px]"
+          >
+            what <span className="font-semibold">our partners</span> say
+          </h2>
 
-        <p
-          className="m-0 mt-12 max-w-[1160px] w-full min-w-0 self-stretch text-blueprint-black font-caveat text-heading-hand leading-[140%] mb-9"
-        >
-          [The work SFU Blueprint has done] is much appreciated and there is a lot
-          of thanks that cannot really be simply put into words... Volunteers at OCB
-          put in thousands of hours of work behind the scene to make everything
-          happen. The tool that you have created for us will streamline our process
-          to better support and facilitate all the volunteers at OCB. Time is a very
-          valuable and finite resource for us at a small non-profit organization and
-          it will allow us to manage it better and more efficiently.
-        </p>
+          <p
+            className="m-0 mt-12 w-full min-w-0 text-blueprint-black font-caveat text-heading-hand leading-[140%] mb-9"
+          >
+            [The work SFU Blueprint has done] is much appreciated and there is a lot
+            of thanks that cannot really be simply put into words... Volunteers at OCB
+            put in thousands of hours of work behind the scene to make everything
+            happen. The tool that you have created for us will streamline our process
+            to better support and facilitate all the volunteers at OCB. Time is a very
+            valuable and finite resource for us at a small non-profit organization and
+            it will allow us to manage it better and more efficiently.
+          </p>
 
-        <div className="max-w-[241px] w-full min-w-0 self-stretch">
-          <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
-            CAVAN HUA
-          </p>
-          <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
-            VOLUNTEER COORDINATOR AT OCB
-          </p>
+          <div className="w-full min-w-0 max-w-[min(100%,calc(100vw*241/1422))]">
+            <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
+              CAVAN HUA
+            </p>
+            <p className="m-0 text-blueprint-black font-poppins text-body-s-reg uppercase">
+              VOLUNTEER COORDINATOR AT OCB
+            </p>
+          </div>
         </div>
       </section>
 
-      {/* NPO project proposal ΓÇö mobile: full-bleed bp-blue, white type, white CTA; md+: gray card (Figma) */}
+      {/* NPO project proposal — mobile: full-bleed #0146BE, white type, white CTA; md+: gray card */}
       <section
         className="mt-[148px] max-md:mt-16 mb-12 md:mb-16
                 -mx-6 min-w-0 md:-mx-10 xl:-mx-36
-                max-md:bg-blueprint-blue max-md:py-12 max-md:!px-6
+                max-md:bg-blueprint-navyblue max-md:py-12 max-md:!px-6
                 px-3 sm:px-4 md:px-5 xl:px-6 md:bg-transparent"
       >
         <div
           className="w-full box-border shrink-0 flex flex-col justify-center items-stretch
                 max-md:bg-transparent max-md:p-0 max-md:min-h-0
-                bg-blueprint-npoSection rounded-[20px]
+                md:bg-blueprint-gray-neutral rounded-[20px]
                 pt-[72px] pb-[96px] px-6 sm:px-10 md:px-[103px]
                 md:min-h-[560px]"
         >
           <div className="flex flex-col w-full max-w-[931px] mx-auto justify-center items-stretch">
             <div className="mb-8 flex w-full items-start gap-[26px] max-md:mb-10 md:mb-12 max-md:gap-0">
               <span
-                className="mt-4 hidden shrink-0 w-[22px] h-[22px] rounded-[5px] bg-blueprint-blue md:block"
+                className="mt-4 hidden shrink-0 w-[22px] h-[22px] rounded-[5px] bg-blueprint-navyblue md:block"
                 aria-hidden
               />
               <h2
@@ -292,9 +297,9 @@ const NonprofitsPage = () => {
                 href="/nonprofits/proposal"
                 className="inline-flex w-full shrink-0 items-center justify-center gap-[10px] rounded-[5px] transition-colors
                 max-md:mt-10 max-md:min-h-[52px] max-md:px-6 max-md:py-3.5 max-md:bg-white max-md:hover:bg-blueprint-offwhite
-                md:mt-0 md:box-border md:h-[60px] md:w-[200px] md:max-w-full md:self-start md:px-[44px] md:py-[14px] md:bg-blueprint-black md:hover:bg-blueprint-darkestGrey"
+                md:mt-0 md:box-border md:h-[60px] md:w-[200px] md:max-w-full md:self-start md:px-[44px] md:py-[14px] md:bg-blueprint-black md:hover:bg-blueprint-darkestGrey md:active:bg-blueprint-neutral-mid"
               >
-                <span className="whitespace-nowrap text-center font-poppins uppercase leading-[normal] text-mobile-body-m-bold text-blueprint-blue md:text-body-m-bold md:text-blueprint-white">
+                <span className="whitespace-nowrap text-center font-poppins uppercase leading-[normal] text-mobile-body-m-bold text-blueprint-navyblue md:text-body-m-bold md:text-blueprint-white">
                   PROPOSAL FORM
                 </span>
               </a>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -32,7 +32,7 @@ const ProjectsPage = () => {
 
   return (
     <PageContainer
-      className="bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat bg-blueprint-gray-light 
+      className="bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat bg-bp-lightest-grey 
                  min-[1280px]:bg-[calc(100%+585px)_-500px]
                  max-[1279px]:bg-[calc(100%+689px)_-500px]
                  max-md:bg-[url('/images/non-profit/mobile_partner_crosspoint.svg')] max-md:bg-[calc(100%+130px)_-45px]"

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -115,7 +115,7 @@ const SOCIAL_LINKS = [
       "Follow us on Instagram to stay updated on events and see what our team is working on.",
     href: "https://www.instagram.com/sfublueprint/",
     accentColor: "#FFC3E8",
-    icon: <InstagramIcon className="w-full h-full text-blueprint-black" />,
+    icon: <InstagramIcon className="w-full h-full text-bp-black" />,
   },
   {
     platform: "youtube",
@@ -123,7 +123,7 @@ const SOCIAL_LINKS = [
       "Subscribe to our Youtube channel for our Career Talks podcast series!",
     href: "https://www.youtube.com/@sfublueprint",
     accentColor: "#FFB347",
-    icon: <YoutubeIcon className="w-full h-full text-blueprint-black" />,
+    icon: <YoutubeIcon className="w-full h-full text-bp-black" />,
   },
   {
     platform: "discord",
@@ -131,7 +131,7 @@ const SOCIAL_LINKS = [
       "Join our Discord for hiring announcements and a place to ask any questions about Blueprint!",
     href: "https://discord.gg/sfublueprint",
     accentColor: "#9CC0FF",
-    icon: <DiscordIcon className="w-full h-full text-blueprint-black" />,
+    icon: <DiscordIcon className="w-full h-full text-bp-black" />,
   },
   {
     platform: "linkedin",
@@ -139,7 +139,7 @@ const SOCIAL_LINKS = [
       "Curious to see what our members are up to? Connect with Blueprint on Linkedin!",
     href: "https://www.linkedin.com/company/sfublueprint/",
     accentColor: "#71EC59",
-    icon: <LinkedinIcon className="w-full h-full text-blueprint-black" />,
+    icon: <LinkedinIcon className="w-full h-full text-bp-black" />,
   },
 ];
 
@@ -151,9 +151,9 @@ const StudentsPage = () => {
   };
 
   return (
-    <div className="w-full overflow-x-hidden bg-blueprint-gray-light">
+    <div className="w-full overflow-x-hidden bg-bp-lightest-grey">
       {/* Hero Section - Dark Background */}
-      <section className="relative bg-blueprint-black z-5
+      <section className="relative bg-bp-black z-5
                           bg-[url('/images/non-profit/desktop_partner_crosspoint.svg')] bg-no-repeat
                           min-[1622.1px]:bg-[calc((50vw+800px)-1689px)_-360px]
                           max-[1622px]:bg-[calc(100%+585px)_-360px]
@@ -204,11 +204,11 @@ const StudentsPage = () => {
 
       <div className="std-max">
       {/* Typical Experience Section */}
-      <section className="w-full px-6 md:px-10 xl:px-36 pt-[108px] max-md:pt-[60px] bg-blueprint-gray-light">
+      <section className="w-full px-6 md:px-10 xl:px-36 pt-[108px] max-md:pt-[60px] bg-bp-lightest-grey">
         {/* Section Intro */}
         <div className="max-w-[852px] mb-[90px] max-md:mb-[50px]">
           <h2
-            className="font-poppins text-[48px] leading-none tracking-[-0.96px] text-blueprint-black mb-[24px]
+            className="font-poppins text-[48px] leading-none tracking-[-0.96px] text-bp-black mb-[24px]
                        max-md:text-[28px] max-md:tracking-[-0.56px] max-md:mb-[16px]"
           >
             <span className="font-normal">a </span>
@@ -216,7 +216,7 @@ const StudentsPage = () => {
             <span className="font-normal"> at sfu blueprint</span>
           </h2>
           <p
-            className="font-poppins text-[16px] leading-normal text-blueprint-black max-w-[852px]
+            className="font-poppins text-[16px] leading-normal text-bp-black max-w-[852px]
                        max-md:text-[14px]"
           >
             {EXPERIENCE_CONTENT.body}
@@ -226,7 +226,7 @@ const StudentsPage = () => {
         {/* Work with a Team */}
         <div className="mb-[90px] max-md:mb-[50px]">
         <h3
-                className="font-poppins text-[36px] leading-[1.4] tracking-[-0.72px] text-blueprint-black font-semibold
+                className="font-poppins text-[36px] leading-[1.4] tracking-[-0.72px] text-bp-black font-semibold
                            max-md:text-[22px] max-md:tracking-[-0.44px] max-md:pb-6"
               >
             <span>work with a team</span>
@@ -249,21 +249,21 @@ const StudentsPage = () => {
         {/* Work with a Timeline */}
         <div className="mb-[90px] max-md:mb-[50px]">
         <h3
-                className="font-poppins text-[36px] leading-[1.4] tracking-[-0.72px] text-blueprint-black font-semibold
+                className="font-poppins text-[36px] leading-[1.4] tracking-[-0.72px] text-bp-black font-semibold
                            max-md:text-[22px] max-md:tracking-[-0.44px]"
               >
                 {TIMELINE_CONTENT.heading}
               </h3>
           <p
-            className="font-poppins text-[16px] leading-normal text-blueprint-black max-w-[584px]
+            className="font-poppins text-[16px] leading-normal text-bp-black max-w-[584px]
                        max-md:text-[14px] max-md:max-w-full"
           >
             {TIMELINE_CONTENT.body}
           </p>
 
           {/* Timeline image placeholder */}
-          <div className="mt-[36px] w-full h-[289px] max-md:h-[131px] bg-blueprint-lightGrey rounded-lg flex items-center justify-center">
-            <span className="font-poppins text-[16px] text-blueprint-darkGrey">
+          <div className="mt-[36px] w-full h-[289px] max-md:h-[131px] bg-bp-light-grey rounded-lg flex items-center justify-center">
+            <span className="font-poppins text-[16px] text-bp-dark-grey">
               Image placeholder
             </span>
           </div>
@@ -275,12 +275,12 @@ const StudentsPage = () => {
             {/* Text content */}
             <div className="flex flex-col gap-[24px] shrink-0 max-w-[468px] max-md:max-w-full">
               <h3
-                className="font-poppins text-4xl leading-[1.4] tracking-[-0.72px] text-blueprint-black font-semibold
+                className="font-poppins text-4xl leading-[1.4] tracking-[-0.72px] text-bp-black font-semibold
                            max-md:text-[22px] max-md:tracking-[-0.44px]"
               >
                 {SOCIALS_CONTENT.heading}
               </h3>
-              <p className="font-poppins text-[16px] leading-normal text-blueprint-black max-w-[451px] max-md:text-[14px]">
+              <p className="font-poppins text-[16px] leading-normal text-bp-black max-w-[451px] max-md:text-[14px]">
                 {SOCIALS_CONTENT.body}
               </p>
             </div>
@@ -313,7 +313,7 @@ const StudentsPage = () => {
       {/* Open Positions Section */}
       <section
         id="open-positions"
-        className="bg-blueprint-black rounded-[20px] mx-[71px] flex flex-wrap items-start md:gap-[40px] xl:gap-[127px]
+        className="bg-bp-black rounded-[20px] mx-[71px] flex flex-wrap items-start md:gap-[40px] xl:gap-[127px]
                    py-[117px] px-[115px] overflow-hidden
                    max-lg:flex-col max-lg:gap-[31px] max-lg:pt-[61px] max-lg:pb-[106px] max-lg:px-[19px] max-lg:mx-[16px] max-lg:rounded-[12px]"
       >
@@ -345,7 +345,7 @@ const StudentsPage = () => {
               onClick={() =>
                 window.open("https://discord.gg/sfublueprint", "_blank")
               }
-              className="w-[200px] max-lg:hidden !text-blueprint-black"
+              className="w-[200px] max-lg:hidden !text-bp-black"
             >
               JOIN OUR DISCORD
             </Button>
@@ -393,13 +393,13 @@ const StudentsPage = () => {
           {/* Header */}
           <div className="text-center mb-[48px] max-md:mb-[32px]">
             <h2
-              className="font-caveat text-7xl leading-[1.2] tracking-[-0.96px] text-blueprint-black mb-[12px]
+              className="font-caveat text-7xl leading-[1.2] tracking-[-0.96px] text-bp-black mb-[12px]
                          max-md:text-5xl max-md:tracking-[-0.64px]"
             >
               stay updated
             </h2>
             <p
-              className="font-poppins text-4xl leading-[1.4] tracking-[-0.72px] text-blueprint-black
+              className="font-poppins text-4xl leading-[1.4] tracking-[-0.72px] text-bp-black
                          max-md:text-2xl max-md:tracking-[-0.56px] max-md:leading-10"
             >
               @sfublueprint
@@ -495,7 +495,7 @@ function ApplicationProcessSection() {
   };
 
   return (
-    <section className="w-full px-6 md:px-10 xl:px-36 pb-[140px] max-md:pb-[60px] bg-blueprint-gray-light">
+    <section className="w-full px-6 md:px-10 xl:px-36 pb-[140px] max-md:pb-[60px] bg-bp-lightest-grey">
       {/* Section heading */}
       <h2
         className="font-poppins text-[48px] leading-[1.2] tracking-[-0.96px] text-[#2e2e2e] mb-[48px]
@@ -560,11 +560,11 @@ function ApplicationProcessSection() {
         <div className="flex flex-col gap-[38px]">
           {/* Info session card - only show on MEET BLUEPRINT tab */}
           {activeTab === "MEET BLUEPRINT" && (
-            <div className="bg-blueprint-gray-neutral rounded-[10px] p-[48px] max-md:p-[24px] flex flex-col gap-[32px]">
+            <div className="bg-bp-lighter-grey rounded-[10px] p-[48px] max-md:p-[24px] flex flex-col gap-[32px]">
               {/* Top section */}
               <div className="flex flex-col gap-[12px]">
                 <div className="flex items-start justify-between max-md:flex-col max-md:gap-[16px]">
-                  <div className="flex flex-col gap-[4px] text-blueprint-black w-[366px] max-md:w-full ">
+                  <div className="flex flex-col gap-[4px] text-bp-black w-[366px] max-md:w-full ">
                     <p className="font-poppins font-medium text-[14px] uppercase leading-normal ">
                       upcoming event:
                     </p>
@@ -583,7 +583,7 @@ function ApplicationProcessSection() {
               </div>
 
               {/* Bottom section: date + location */}
-              <div className="flex gap-[52px] text-blueprint-black max-md:flex-col max-md:gap-[24px]">
+              <div className="flex gap-[52px] text-bp-black max-md:flex-col max-md:gap-[24px]">
                 <div className="flex flex-col gap-[10px] w-[199px] ">
                   <p className="font-poppins font-medium text-[14px] uppercase leading-normal">
                     DATE AND TIME:
@@ -643,7 +643,7 @@ function RoleCard({ title, description, color, offset }: RoleCardProps) {
         </p>
       </div>
       {/* Description */}
-      <p className="font-poppins text-[16px] leading-normal text-blueprint-black max-md:text-[14px]">
+      <p className="font-poppins text-[16px] leading-normal text-bp-black max-md:text-[14px]">
         {description}
       </p>
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,7 @@ module.exports = {
     extend: {
       colors: {
         blueprint: {
-          // Brand
+          // Brand (#0146BE = navyblue / bp blue for primary fills; blue = brighter UI/link blue)
           blue: "#0177E8",
           black: "#2A2A2A",
           white: "#FFFFFF",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,61 +10,23 @@ module.exports = {
     darkMode: "false",
     extend: {
       colors: {
-        blueprint: {
-          // Brand (#0146BE = navyblue / bp blue for primary fills; blue = brighter UI/link blue)
-          blue: "#0177E8",
-          black: "#2A2A2A",
-          white: "#FFFFFF",
-          offwhite: "#FCFCFC",
-          deepblue: "#0D579F",
-          navyblue: "#0146BE",
-          orange: "#F49F00",
-          // Link states (nav, footer, buttons)
-          linkHover: "#0146BE",
-          linkActive: "#002F80",
-          hoverBlue: "#00389B",
-          // Accent (palette: bp-accent-*)
-          accent: {
-            lightBlue: "#A5C6FF",
-            veryLightBlue: "#D3E3FF",
-            mediumBlue: "#5387E3",
-            purple: "#D2A6FB",
-          },
-          // Filter pills on white/light surfaces (Figma: default border + translucent gray fill)
-          filterOnWhite: {
-            border: "#CACACA",
-            bgDefault: "rgba(213, 213, 213, 0.30)",
-          },
-          // Neutrals / grey scale (palette: bp-light-grey, bp-grey, bp-dark-grey, bp-lightest-grey)
-          gray: {
-            dark: "#B8B8B8",
-            light: "#F3F3F3",
-            lightest: "#F3F3F3",
-            neutral: "#E8E8E8",
-          },
-          lightGrey: "#D9D9D9",
-          grey: "#AAAAAA",
-          darkGrey: "#777777",
-          // Text (body / secondary copy)
-          textGray: "#6A6A6A",
-          /** Desktop heading / m-reg (Figma) */
-          heading: "#2E2E2E",
-          neutral: {
-            dark: "#2A2A2A",
-            muted: "#D9D9D9",
-            mutedAlt: "#AAAAAA",
-            mid: "#777777",
-          },
-          // Open Role Card: bp-darkest-grey (default/hover fill), bp-black (pressed fill)
-          darkestGrey: "#383838",
-          // Role accent colors: dev green, pm orange, designer purple, executive light blue
-          roleAccent: {
-            dev: "#71EC59",
-            pm: "#F49F00",
-            designer: "#D2A6FB",
-            executive: "#9CC0FF",
-          },
-        },
+        // Core brand palette
+        "bp-black": "#2A2A2A",
+        "bp-darkest-grey": "#383838",
+        "bp-dark-grey": "#777777",
+        "bp-grey": "#AAAAAA",
+        "bp-light-grey": "#D9D9D9",
+        "bp-lighter-grey": "#E8E8E8",
+        "bp-lightest-grey": "#F3F3F3",
+        "bp-white": "#FFFFFF",
+        "bp-orange": "#F49F00",
+        "bp-blue": "#0146BE",
+        "bp-hover-blue": "#00389B",
+        "bp-pressed-blue": "#002F80",
+        "bp-accent-medium-blue": "#5387E3",
+        "bp-accent-light-blue": "#A5C6FF",
+        "bp-accent-very-light-blue": "#D3E3FF",
+        "bp-accent-purple": "#D2A6FB",
       },
       fontFamily: {
         caveat: ['Caveat', 'cursive'],


### PR DESCRIPTION
## Summary
Updates the NPO page to match the latest Figma designs, including layout spacing, typography adjustments, and visual refinements across key sections. Also includes responsive fixes and supporting Tailwind token updates.

---

## Problem
The existing NPO page did not align with the updated design system:
- Vertical spacing felt too tight, reducing readability
- Section headers did not follow the new mixed font-weight style
- Evaluation cards had outdated borders, spacing, and colors
- Proposal section styling (colors, spacing, accents) was inconsistent
- Mobile responsiveness and typography did not match design specs

---

## What Changed

### General
- Updated vertical spacing across the page to follow new guidelines, improving readability and visual hierarchy
- Refactored section headers to use mixed font weights (bold + regular)

### Landing / Hero Section
- Fixed mobile crosspoint SVG positioning relative to title
- Adjusted title and body widths to match design proportions
- Updated typography tokens for consistency with design system
- Increased subheading (`heading-xs-reg`) line height to **140%**
- Added **32px top padding under navbar**
- Applied slight polaroid positioning adjustment ("nudge") to match Figma

### Evaluation Cards / Project Traits
- Removed card borders for a cleaner look
- Increased horizontal gap to **24px**
- Updated card colors to new design tokens
- Adjusted mobile heading/body typography specs
- Refined evaluation card layout for better responsiveness

### NPO Project Proposal Section
- Added new background color `#E8E8E8` to Tailwind theme
- Updated spacing to align with new vertical rhythm
- Implemented accent square element
- Updated colors to match new design

### Partners Say (Desktop)
- Constrained quote width to **1160px**
- Set **36px gap** between elements
- Adjusted attribution width to **241px**
- Applied **Caveat + body-s-reg** typography pairing
- Updated quote line height to **140%**

### Tailwind / Design Tokens
- Added new color token for proposal section background
- Tweaked typography and spacing tokens to support updated design
- Ensured consistent usage across components

---

## Design Reference
Figma: NPO Page Revamp  
https://www.figma.com/design/XXZoMr71dMjBKOOI7lgCAJ/2026-Website-Revamp?node-id=1668-5085&t=1nm6cWb8JZJoLrpE-1

---

## Notes
- Changes are purely visual; no functional logic was modified
- Focused on improving spacing, hierarchy, and responsiveness
- Aligns page with updated design system and tokens

---

## Testing
- Verified layout and spacing across breakpoints (mobile, tablet, desktop)
- Checked typography and token consistency
- Confirmed no visual regressions in adjacent sections

---

## Screenshots
<!-- Add before/after screenshots if needed -->

Screenshots:
1. Desktop
<img width="1918" height="866" alt="image" src="https://github.com/user-attachments/assets/3f4e4d94-da52-4905-9f4b-95be0cc15962" />
<img width="1909" height="855" alt="image" src="https://github.com/user-attachments/assets/65dbada5-89bb-4264-887f-701fb344148b" />
<img width="1857" height="691" alt="image" src="https://github.com/user-attachments/assets/abd8716b-da96-4e61-8497-e68044eaa465" />
<img width="1728" height="717" alt="image" src="https://github.com/user-attachments/assets/0e678ac3-9b7a-48a4-af90-73f41c4fd913" />
<img width="1895" height="762" alt="image" src="https://github.com/user-attachments/assets/bc88ae96-e9ae-429d-95aa-289942a9a645" />

2. Mobile:

<img width="438" height="668" alt="image" src="https://github.com/user-attachments/assets/77c14613-01d4-4123-a426-08bc588f7bda" />
<img width="478" height="685" alt="image" src="https://github.com/user-attachments/assets/ee1b679a-dbdc-4012-9174-f0ead830c9ca" />
<img width="428" height="644" alt="image" src="https://github.com/user-attachments/assets/85f2018f-3f15-4ae0-9e0b-25610ce51b79" />

Closes #92 