### PR TITLE
feat(about): Meet the Team section with filters, grid, and alumni CTA

### DIFF
--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,9 +1,207 @@
-import React from "react";
-import BlankPage from "../components/layout/BlankPage";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import PageContainer from "../components/layout/PageContainer";
+import Button from "../components/shared/Button";
+import Filters from "../components/shared/Filters";
+import MemberCard, { memberRoleType } from "../components/shared/MemberCard";
+
+type TeamMember = {
+  name: string;
+  role: string;
+  roleType: memberRoleType;
+  photoUrl?: string;
+  linkedinUrl?: string;
+};
+
+/** Polaroid photo placeholder — solid fill until real headshots are wired */
+const POLAROID_PLACEHOLDER_PHOTO =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800"><rect width="100%" height="100%" fill="#686974"/></svg>'
+  );
+
+const FILTER_TABS: { label: string; roleType: memberRoleType }[] = [
+  { label: "Executives", roleType: "exec" },
+  { label: "Project Managers", roleType: "pm" },
+  { label: "Designers", roleType: "designer" },
+  { label: "Tech Leads", roleType: "techLead" },
+  { label: "Developers", roleType: "dev" },
+];
+
+/** Placeholder roster — replace with CMS or API when available */
+const TEAM_MEMBERS: TeamMember[] = [
+  {
+    name: "Alex Rivera",
+    role: "developer",
+    roleType: "dev",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Casey Morgan",
+    role: "designer",
+    roleType: "designer",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Dana Singh",
+    role: "project manager",
+    roleType: "pm",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Elliot Park",
+    role: "tech lead",
+    roleType: "techLead",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Jordan Lee",
+    role: "executive",
+    roleType: "exec",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Morgan Blake",
+    role: "developer",
+    roleType: "dev",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Priya Nair",
+    role: "designer",
+    roleType: "designer",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Riley Chen",
+    role: "project manager",
+    roleType: "pm",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+];
 
 const AboutPage = () => {
-  return <BlankPage title="About Page" />;
-  
+  const navigate = useNavigate();
+  const [selectedRoles, setSelectedRoles] = useState<memberRoleType[]>([]);
+
+  const toggleRole = (roleType: memberRoleType) => {
+    setSelectedRoles((prev) =>
+      prev.includes(roleType) ? prev.filter((r) => r !== roleType) : [...prev, roleType]
+    );
+  };
+
+  const displayedMembers = useMemo(() => {
+    const base =
+      selectedRoles.length === 0
+        ? TEAM_MEMBERS
+        : TEAM_MEMBERS.filter((m) => selectedRoles.includes(m.roleType));
+    return [...base].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+    );
+  }, [selectedRoles]);
+
+  return (
+    <PageContainer className="flex max-md:!px-0 max-md:overflow-x-hidden flex-col items-stretch bg-bp-lightest-grey pb-[100px] max-md:pb-[60px] xl:!px-[56px] 2xl:!px-[56px]">
+      <section
+        className="meet-the-team mx-auto w-full max-w-[1328px] max-md:max-w-none rounded-[20px] bg-bp-lighter-grey max-md:rounded-none max-md:bg-bp-blue max-md:px-6 max-md:pt-16 max-md:pb-20 sm:px-8 md:px-10 md:pt-20 md:pb-24 xl:px-14"
+        aria-labelledby="meet-the-team-heading"
+      >
+        <h2
+          id="meet-the-team-heading"
+          className="mb-8 max-md:mb-6 max-md:text-left md:mb-10 md:text-center"
+        >
+          <span className="font-poppins text-mobile-heading-l-bold text-bp-white md:hidden">
+            <span className="font-normal">our </span>
+            <span className="font-bold">team</span>
+          </span>
+          <span className="hidden font-caveat font-normal text-bp-black text-mobile-heading-hand tablet:text-heading-hand desktop:text-[78px] desktop:leading-none desktop:tracking-normal md:inline">
+            meet the team
+          </span>
+        </h2>
+
+        <div
+          className="mb-8 flex max-md:mb-6 max-md:justify-start max-md:gap-2 md:mb-10 flex-wrap flex-row justify-center gap-x-3 gap-y-3 md:gap-x-[14px]"
+          role="toolbar"
+          aria-label="Filter team by role"
+        >
+          {FILTER_TABS.map(({ label, roleType }) => {
+            const selected = selectedRoles.includes(roleType);
+            return (
+              <div key={roleType} className="contents">
+                <span className="max-md:contents md:hidden">
+                  <Filters
+                    title={label}
+                    state={selected ? "filled" : "outlined"}
+                    variant="dark"
+                    className="max-md:hover:!border-bp-white max-md:hover:!bg-bp-white/15"
+                    onClick={() => toggleRole(roleType)}
+                  />
+                </span>
+                <span className="hidden md:contents">
+                  <Filters
+                    title={label}
+                    variant="light"
+                    state={selected ? "selected" : "default"}
+                    onClick={() => toggleRole(roleType)}
+                  />
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          className="grid w-full max-md:grid-cols-2 max-md:gap-3 max-md:justify-items-stretch justify-items-center gap-6 md:gap-8 md:[grid-template-columns:repeat(auto-fit,minmax(250px,1fr))]"
+          role="list"
+          aria-live="polite"
+        >
+          {displayedMembers.map((member) => (
+            <div
+              key={member.name}
+              className="flex w-full max-w-[350px] justify-center max-md:max-w-none"
+              role="listitem"
+            >
+              <MemberCard
+                name={member.name}
+                role={member.role}
+                roleType={member.roleType}
+                photoUrl={member.photoUrl}
+                linkedinUrl={member.linkedinUrl}
+                randomRotation
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 flex w-full justify-center max-md:mt-8 md:mt-12">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate("/alumni")}
+            className="w-full md:hidden"
+          >
+            ALUMNI
+          </Button>
+          <Button
+            type="button"
+            variant="tertiary"
+            onClick={() => navigate("/alumni")}
+            className="hidden w-full desktop:h-[60px] desktop:w-[200px] desktop:min-w-[200px] desktop:max-w-[200px] desktop:shrink-0 desktop:px-4 md:flex"
+          >
+            ALUMNI
+          </Button>
+        </div>
+      </section>
+    </PageContainer>
+  );
 };
 
 export default AboutPage;


### PR DESCRIPTION
## Summary
Implements the **Meet the Team** section on the About page: role filters, polaroid-style member cards, responsive layout, and an alumni CTA.  

## What’s Included
- **Meet the Team block** on `/about`
  - `bp-lighter-grey` card on desktop  
  - `bp-blue` full-bleed section on mobile  

- **Heading**
  - Mobile: “our team” (`mobile-heading-l-bold` + weight split)  
  - Desktop: “meet the team” (`Caveat`, `desktop:text-[78px]`, `leading-none`, `tracking-normal`)  

- **Filters**
  - Uses existing `Filters` component  
  - Light pills on desktop  
  - Dark outlined/filled on mobile  
  - Multi-select with OR logic  
  - Empty selection = show all  

- **Grid**
  - `repeat(auto-fit, minmax(250px, 1fr))` on larger screens  
  - 2 columns on mobile  

- **Cards**
  - Uses `MemberCard` only (no custom polaroid markup)  
  - Placeholder photo: `#686974` (SVG data URL)  
  - A–Z sorting after filter  

- **CTA**
  - `Button`
    - Mobile: secondary (white background / blue text)  
    - Desktop: tertiary black (200×60)  
  - Label: **ALUMNI** → `/alumni`  

- **Data**
  - 8 placeholder members  
  - Replace with real roster / CMS later  

## How to Test
1. Open `/about` on mobile and desktop widths  
2. Toggle filters (including multiple selections)  
3. Confirm grid responsiveness and A–Z sorting  
4. Verify member hover / LinkedIn behavior (unchanged, handled in `MemberCard`)  
5. Click **ALUMNI** and confirm navigation to `/alumni`  

## Notes
- Placeholder headshots and names are temporary  
- Will be replaced once real assets and copy are available  

## Screenshots:
- Desktop: 
<img width="975" height="816" alt="image" src="https://github.com/user-attachments/assets/b86f1869-e740-424e-ac60-7f34626e5d37" />
- Mobile:
<img width="941" height="1252" alt="image" src="https://github.com/user-attachments/assets/1244cf51-e191-4b91-b0cc-e036168fc08f" />
<img width="975" height="1215" alt="image" src="https://github.com/user-attachments/assets/28e7ff9f-308b-4376-b654-409634bd5edd" />

Closes #99 

