### PR TITLE
fiixed about us page and tokenization of components used

### DIFF
--- a/src/components/shared/InfoCard.tsx
+++ b/src/components/shared/InfoCard.tsx
@@ -1,8 +1,6 @@
-import PageContainer from "../layout/PageContainer"
-
 const INFO_CARD_ACCENT_SQUARE_BG = {
-  "blueprint-navyblue": "bg-blueprint-navyblue",
-  "blueprint-roleAccent-pm": "bg-blueprint-roleAccent-pm",
+  "bp-blue": "bg-bp-blue",
+  "bp-orange": "bg-bp-orange",
 } as const
 
 export type InfoCardProps = {
@@ -13,13 +11,13 @@ export type InfoCardProps = {
 }
 function InfoCard({ title, heading, body, color }: InfoCardProps) {
     return (
-        <div className="flex flex-col gap-6 bg-blueprint-white rounded-[5px] min-w-[357px] h-[321px] px-7 pt-6 pb-12 
+        <div className="flex flex-col gap-6 bg-bp-white rounded-[5px] min-w-[357px] h-[321px] px-7 pt-6 pb-12 
         lg:max-w-[569px] lg:h-[382px]  lg:px-12 lg:pt-9 lg:pb-16">
               {/* Gray Tag */}
-              <div className="bg-blueprint-gray-lightest text-zinc-800 text-[10px] font-medium uppercase font-['Poppins'] w-fit rounded-[5px] whitespace-nowrap
+              <div className="bg-bp-lightest-grey text-zinc-800 text-[10px] font-medium uppercase font-['Poppins'] w-fit rounded-[5px] whitespace-nowrap
                flex flex-row items-center gap-2 py-2 px-3">
                 <div
-                  className={`shrink-0 rounded-sm bg-${color} w-3 h-3`}
+                  className={`shrink-0 rounded-sm ${INFO_CARD_ACCENT_SQUARE_BG[color]} w-3 h-3`}
                   aria-hidden
                 />
                 <p>{title}</p>
@@ -28,12 +26,12 @@ function InfoCard({ title, heading, body, color }: InfoCardProps) {
               <div className="gap-4 flex flex-col">
 
                 {/* Heading */}               
-                  <p className="font-['Poppins'] text-blueprint-black text-lg md:text-2xl leading-normal">
+                  <p className="font-['Poppins'] text-bp-black text-lg md:text-2xl leading-normal">
                     {heading}
                   </p>   
 
                 {/* Body */}              
-                  <p className="flex font-['Poppins'] text-blueprint-black text-sm md:text-base leading-normal">
+                  <p className="flex font-['Poppins'] text-bp-black text-sm md:text-base leading-normal">
                   {body}
                   </p>
               

--- a/src/components/shared/PolaroidPhoto.tsx
+++ b/src/components/shared/PolaroidPhoto.tsx
@@ -20,8 +20,8 @@ type PolaroidPhotoProps = {
 const PolaroidPhoto = ({imageSrc, caption, alt, className = "", style}: PolaroidPhotoProps) => {
     // Outer container for component
     return (
-    <div className={`bg-blueprint-white gap-[8px] shadow-[2px_4px_10px_0px_rgba(0,0,0,0.07)] w-[306px] h-[270px] pt-[11px] pr-[12px] pb-[15px] pl-[13px] 
-                    md:h-[345px] md:w-[377px] md:px-[18px] md:pt[20px] md:pb[24px] overflow-hidden ${className}`}
+    <div className={`bg-bp-white gap-[8px] shadow-[2px_4px_10px_0px_rgba(0,0,0,0.07)] w-[306px] h-[270px] pt-[11px] pr-[12px] pb-[15px] pl-[13px] 
+                    md:h-[345px] md:w-[377px] md:px-[18px] md:pt-[20px] md:pb-[24px] overflow-hidden ${className}`}
          style={style}>
         {/* Inner container for all elements */}
         <div className="flex flex-col self-stretch shrink-0 items-center gap-[8px] md:gap-[10px]"> 

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -16,14 +16,14 @@ const OUR_MEMBERS_CONTENT = {
   title: "Our members",
   heading: "Our talented members come from diverse cultures, professions, and social backgrounds.",
   body: "With a passion for social good and dedication to creating beautiful technology, our student project teams work alongside nonprofits to help them better serve their communities.",
-  color: "blueprint-navyblue",
+  color: "bp-blue",
 } as const;
 
 const BLUEPRINT_MULTINATIONAL_CONTENT = {
   title: "Blueprint Multinational",
   heading: "This chapter of Blueprint is part of a much larger multinational community, originally started at UC Berkeley.",
   body: "As the fifth established chapter in Canada, our team is based largely at Simon Fraser University, and operating as a registered non profit!",
-  color: "blueprint-roleAccent-pm",
+  color: "bp-orange",
 } as const;
 
 type TeamMember = {
@@ -220,19 +220,19 @@ const AboutPage = () => {
   const imagesToShow = GroupImages.slice(baseVisible, baseVisible + extraCount);
 
   return (
-    <PageContainer className="bg-blueprint-gray-lightest max-md:overflow-x-hidden">
+    <PageContainer className="bg-bp-lightest-grey max-md:overflow-x-hidden">
       {/* Main Container */}
       <div className="pt-main-mobile-top md:pt-main-desktop-top flex flex-col justify-between">
         {/* About us section */}
         <div className="flex md:flex-row flex-col justify-between md:mb-[100px] flex-wrap">
           <div className="flex flex-col md:justify-between max-md:pb-[62px] gap-3 md:gap-6">
             {/* Title/text */}
-            <h1 className="font-poppins text-5xl md:text-7xl leading-none tracking-[-0.96px] text-blueprint-black ">
+            <h1 className="font-poppins text-5xl md:text-7xl leading-none tracking-[-0.96px] text-bp-black ">
               <strong>about</strong> us
             </h1>
 
             {/* Text */}
-            <p className="font-poppins text-xl md:text-3xl leading-7 md:leading-10 text-blueprint-black w-90 md:w-[684px]">
+            <p className="font-poppins text-xl md:text-3xl leading-7 md:leading-10 text-bp-black w-90 md:w-[684px]">
               building innovative, tech-based solutions for communities and public welfare is the mission that brings us together.
             </p>
           </div>
@@ -327,7 +327,7 @@ const AboutPage = () => {
         </div>
 
         {/* Values Section — Rive needs a real URL from Vite (?url) and a sized box for the canvas */}
-        <div className="relative z-10 w-full shrink-0 pb-[280px] max-md:pb-[420px] md:pb-0 max-md:overflow-hidden">
+        <div className="relative z-10 w-full shrink-0 pb-[280px] max-md:pb-[420px] md:z-0 md:pb-0 max-md:overflow-hidden">
           <div className="pointer-events-none relative z-10 flex flex-col md:gap-10 md:pb-[566px]">
             <h2 className="pointer-events-auto flex flex-col max-md:justify-center max-md:items-center font-poppins text-5xl md:text-7xl">
               our <strong>values</strong>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
 import CameraButton from "../components/shared/CameraButton";
 import PolaroidPhoto from "../components/shared/PolaroidPhoto";
@@ -7,6 +8,9 @@ import InfoCard from "../components/shared/InfoCard";
 import { useRive, Layout, Fit, Alignment } from "@rive-app/react-webgl2";
 import revisedRiv from "../assets/rive/Revised-Desktop.riv?url";
 import aboutValuesMobileRiv from "../assets/rive/about-values-mobile.riv?url";
+import Button from "../components/shared/Button";
+import Filters from "../components/shared/Filters";
+import MemberCard, { memberRoleType } from "../components/shared/MemberCard";
 
 const OUR_MEMBERS_CONTENT = {
   title: "Our members",
@@ -20,7 +24,90 @@ const BLUEPRINT_MULTINATIONAL_CONTENT = {
   heading: "This chapter of Blueprint is part of a much larger multinational community, originally started at UC Berkeley.",
   body: "As the fifth established chapter in Canada, our team is based largely at Simon Fraser University, and operating as a registered non profit!",
   color: "blueprint-roleAccent-pm",
-} as const
+} as const;
+
+type TeamMember = {
+  name: string;
+  role: string;
+  roleType: memberRoleType;
+  photoUrl?: string;
+  linkedinUrl?: string;
+};
+
+/** Polaroid photo placeholder — solid fill until real headshots are wired */
+const POLAROID_PLACEHOLDER_PHOTO =
+  "data:image/svg+xml," +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800"><rect width="100%" height="100%" fill="#686974"/></svg>'
+  );
+
+const FILTER_TABS: { label: string; roleType: memberRoleType }[] = [
+  { label: "Executives", roleType: "exec" },
+  { label: "Project Managers", roleType: "pm" },
+  { label: "Designers", roleType: "designer" },
+  { label: "Tech Leads", roleType: "techLead" },
+  { label: "Developers", roleType: "dev" },
+];
+
+/** Placeholder roster — replace with CMS or API when available */
+const TEAM_MEMBERS: TeamMember[] = [
+  {
+    name: "Alex Rivera",
+    role: "developer",
+    roleType: "dev",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Casey Morgan",
+    role: "designer",
+    roleType: "designer",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Dana Singh",
+    role: "project manager",
+    roleType: "pm",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Elliot Park",
+    role: "tech lead",
+    roleType: "techLead",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Jordan Lee",
+    role: "executive",
+    roleType: "exec",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Morgan Blake",
+    role: "developer",
+    roleType: "dev",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Priya Nair",
+    role: "designer",
+    roleType: "designer",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+  {
+    name: "Riley Chen",
+    role: "project manager",
+    roleType: "pm",
+    photoUrl: POLAROID_PLACEHOLDER_PHOTO,
+    linkedinUrl: "https://www.linkedin.com/company/sfublueprint/",
+  },
+];
 
 /** Random tilt in degrees, roughly -maxDeg … +maxDeg (inclusive). */
 function randomTiltDeg(maxDeg: number, minDeg: number) {
@@ -72,16 +159,18 @@ function AboutValuesRiveMobile() {
 }
 
 const AboutPage = () => {
+  const navigate = useNavigate();
   const INITIAL_VISIBLE = 3;
   const INITIAL_VISIBLE_MOBILE = 2;
   const MAX_VISIBLE = 10;
   /** Column index (0…POLAROID_GRID_COLS-1) for each camera-added polaroid, in click order. */
   const [extraPlacements, setExtraPlacements] = useState<number[]>([]);
-  
+  const [selectedRoles, setSelectedRoles] = useState<memberRoleType[]>([]);
+
   // Create and memoize rotations for each image
   const rotations = useMemo(() => {
     return GroupImages.map(() => randomTiltDeg(20, -20));
-  }, []); // Empty dependency array means this runs once on mount
+  }, []);
 
   // Custom hook to check if the window is at least a certain width return true if window is at least the width
   function useMinWidth(minWidthPx: number): boolean {
@@ -111,19 +200,33 @@ const AboutPage = () => {
     }
   };
 
+  const toggleRole = (roleType: memberRoleType) => {
+    setSelectedRoles((prev) =>
+      prev.includes(roleType) ? prev.filter((r) => r !== roleType) : [...prev, roleType]
+    );
+  };
+
+  const displayedMembers = useMemo(() => {
+    const base =
+      selectedRoles.length === 0
+        ? TEAM_MEMBERS
+        : TEAM_MEMBERS.filter((m) => selectedRoles.includes(m.roleType));
+    return [...base].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+    );
+  }, [selectedRoles]);
+
   const initialImages = GroupImages.slice(0, baseVisible);
   const imagesToShow = GroupImages.slice(baseVisible, baseVisible + extraCount);
-  
 
   return (
-    <PageContainer className="bg-blueprint-gray-lightest">
+    <PageContainer className="bg-blueprint-gray-lightest max-md:overflow-x-hidden">
       {/* Main Container */}
       <div className="pt-main-mobile-top md:pt-main-desktop-top flex flex-col justify-between">
-          
         {/* About us section */}
         <div className="flex md:flex-row flex-col justify-between md:mb-[100px] flex-wrap">
           <div className="flex flex-col md:justify-between max-md:pb-[62px] gap-3 md:gap-6">
-          {/* Title/text */}
+            {/* Title/text */}
             <h1 className="font-poppins text-5xl md:text-7xl leading-none tracking-[-0.96px] text-blueprint-black ">
               <strong>about</strong> us
             </h1>
@@ -135,49 +238,48 @@ const AboutPage = () => {
           </div>
 
           <div className="flex items-center">
-          <CameraButton onClick={handleCameraClick} />
+            <CameraButton onClick={handleCameraClick} />
           </div>
         </div>
-        
+
         {/* Photos Container, 3 photos then on click of Camera button, new photo drops ontop of existing photos (randomized rotation)*/}
         <div className="flex justify-center">
-
-        {/* Desktop photos container */}
-        <div className="max-md:hidden">
-          <div className="relative md:grid md:grid-cols-3 md:justify-items-center flex flex-col max-w-[1160px] flex-wrap mb-[50px]"> 
-            {initialImages.map((image, index) => (
-              <PolaroidPhoto
-                key={image.id}
-                imageSrc={image.image}
-                caption={image.caption}
-                alt={image.caption}
-                style={{ transform: `rotate(${rotations[index]}deg)` }}
-              />
-            ))}
+          {/* Desktop photos container */}
+          <div className="max-md:hidden">
+            <div className="relative md:grid md:grid-cols-3 md:justify-items-center flex flex-col max-w-[1160px] flex-wrap mb-[50px]">
+              {initialImages.map((image, index) => (
+                <PolaroidPhoto
+                  key={image.id}
+                  imageSrc={image.image}
+                  caption={image.caption}
+                  alt={image.caption}
+                  style={{ transform: `rotate(${rotations[index]}deg)` }}
+                />
+              ))}
+            </div>
           </div>
-        </div>
 
-        {/* Mobile photos container */}
-        <div className="md:hidden mb-[-50px]">
-          <div className="relative flex flex-col max-w-[306px]">
-            <span className="relative z-10 translate-x-24">
-              <PolaroidPhoto
-                imageSrc={initialImages[0].image}
-                caption={initialImages[0].caption}
-                alt={initialImages[0].caption}
-                style={{ transform: `rotate(10deg)` }}
-              />
-            </span>
-            <span className="relative z-0 -translate-x-20 translate-y-[-150px]">
-              <PolaroidPhoto
-                imageSrc={initialImages[1].image}
-                caption={initialImages[1].caption}
-                alt={initialImages[1].caption}
-                style={{ transform: `rotate(-8deg)` }}
-              />
-            </span>
+          {/* Mobile photos container */}
+          <div className="md:hidden mb-[-50px]">
+            <div className="relative flex flex-col max-w-[306px]">
+              <span className="relative z-10 translate-x-24">
+                <PolaroidPhoto
+                  imageSrc={initialImages[0].image}
+                  caption={initialImages[0].caption}
+                  alt={initialImages[0].caption}
+                  style={{ transform: `rotate(10deg)` }}
+                />
+              </span>
+              <span className="relative z-0 -translate-x-20 translate-y-[-150px]">
+                <PolaroidPhoto
+                  imageSrc={initialImages[1].image}
+                  caption={initialImages[1].caption}
+                  alt={initialImages[1].caption}
+                  style={{ transform: `rotate(-8deg)` }}
+                />
+              </span>
+            </div>
           </div>
-        </div>
 
           {/* Drops new photos on top of existing photos */}
           <div className="absolute grid h-[200px] md:h-[500px] grid-cols-7 grid-rows-1 translate-y-12 w-full justify-items-center z-20">
@@ -190,49 +292,144 @@ const AboutPage = () => {
                   caption={image.caption}
                   alt={image.caption}
                   className="animate-popIn"
-                  style={{
-                    gridColumn: col + 1,
-                    gridRow: 1,
-                    transform: `rotate(${rotations[baseVisible + index]}deg)`,
-                    zIndex: index,
-                    '--rotation': `${rotations[baseVisible + index]}deg`,
-                  } as React.CSSProperties}
+                  style={
+                    {
+                      gridColumn: col + 1,
+                      gridRow: 1,
+                      transform: `rotate(${rotations[baseVisible + index]}deg)`,
+                      zIndex: index,
+                      "--rotation": `${rotations[baseVisible + index]}deg`,
+                    } as React.CSSProperties
+                  }
                 />
               );
             })}
-          
           </div>
-          
+
           {/* Info Cards Container*/}
         </div>
-          <div className="relative z-10 md:pt-[108px] flex flex-col items-center justify-center gap-2 pb-[148px] lg:flex-row">
-             {/* Our members  */}
-            <InfoCard title={OUR_MEMBERS_CONTENT.title} heading={OUR_MEMBERS_CONTENT.heading} body={OUR_MEMBERS_CONTENT.body} color={OUR_MEMBERS_CONTENT.color} />
-            
+        <div className="relative z-10 md:pt-[108px] flex flex-col items-center justify-center gap-2 pb-[148px] lg:flex-row">
+          {/* Our members  */}
+          <InfoCard
+            title={OUR_MEMBERS_CONTENT.title}
+            heading={OUR_MEMBERS_CONTENT.heading}
+            body={OUR_MEMBERS_CONTENT.body}
+            color={OUR_MEMBERS_CONTENT.color}
+          />
 
-            {/* Blueprint Multinational */}
-            <InfoCard title={BLUEPRINT_MULTINATIONAL_CONTENT.title} heading={BLUEPRINT_MULTINATIONAL_CONTENT.heading} body={BLUEPRINT_MULTINATIONAL_CONTENT.body} color={BLUEPRINT_MULTINATIONAL_CONTENT.color} />
-          </div>
+          {/* Blueprint Multinational */}
+          <InfoCard
+            title={BLUEPRINT_MULTINATIONAL_CONTENT.title}
+            heading={BLUEPRINT_MULTINATIONAL_CONTENT.heading}
+            body={BLUEPRINT_MULTINATIONAL_CONTENT.body}
+            color={BLUEPRINT_MULTINATIONAL_CONTENT.color}
+          />
+        </div>
 
-          {/* Values Section — Rive needs a real URL from Vite (?url) and a sized box for the canvas */}
-          <div className="relative w-full shrink-0 pb-[280px] md:pb-0">
-            <div className="pointer-events-none relative z-10 flex flex-col md:gap-10 md:pb-[566px]">
-              <h2 className="pointer-events-auto flex flex-col max-md:justify-center max-md:items-center font-poppins text-5xl md:text-7xl">
-                our <strong>values</strong>
-              </h2>
-            </div>
-            <div className="absolute md:inset-x-0 bottom-0 z-0 h-[320px] w-full lg:translate-y-[-50px] md:w-full md:h-[1000px]">
-              {isMdUp ? <AboutValuesRiveDesktop /> : <AboutValuesRiveMobile />}
-            </div>
+        {/* Values Section — Rive needs a real URL from Vite (?url) and a sized box for the canvas */}
+        <div className="relative z-10 w-full shrink-0 pb-[280px] max-md:pb-[420px] md:pb-0 max-md:overflow-hidden">
+          <div className="pointer-events-none relative z-10 flex flex-col md:gap-10 md:pb-[566px]">
+            <h2 className="pointer-events-auto flex flex-col max-md:justify-center max-md:items-center font-poppins text-5xl md:text-7xl">
+              our <strong>values</strong>
+            </h2>
           </div>
+          <div className="absolute md:inset-x-0 bottom-0 z-0 h-[400px] w-full md:w-full md:h-[1000px] lg:translate-y-[-50px]">
+            {isMdUp ? <AboutValuesRiveDesktop /> : <AboutValuesRiveMobile />}
+          </div>
+        </div>
       </div>
 
       {/* Meet the Team */}
-      <div className="h-96 bg-blueprint-white">
-        <h2 className="flex flex-col font-poppins md:text-7xl">
-          Meet the Team Polaroid Div
+      <section
+        className="meet-the-team relative z-0 w-full max-md:w-screen max-md:max-w-none max-md:ml-[calc(50%-50vw)] max-md:mr-[calc(50%-50vw)] max-w-[1328px] md:mx-auto rounded-[20px] bg-bp-lighter-grey max-md:rounded-none max-md:bg-bp-blue max-md:px-6 max-md:pt-16 max-md:pb-20 sm:px-8 md:px-10 md:pt-20 md:pb-24 xl:px-14"
+        aria-labelledby="meet-the-team-heading"
+      >
+        <h2
+          id="meet-the-team-heading"
+          className="mb-8 max-md:mb-6 max-md:text-left md:mb-10 md:text-center"
+        >
+          <span className="font-poppins text-mobile-heading-l-bold text-bp-white md:hidden">
+            <span className="font-normal">our </span>
+            <span className="font-bold">team</span>
+          </span>
+          <span className="hidden font-caveat font-normal text-bp-black text-mobile-heading-hand tablet:text-heading-hand desktop:text-[78px] desktop:leading-none desktop:tracking-normal md:inline">
+            meet the team
+          </span>
         </h2>
-      </div>
+
+        <div
+          className="mb-8 flex max-md:mb-6 max-md:justify-start max-md:gap-2 md:mb-10 flex-wrap flex-row justify-center gap-x-3 gap-y-3 md:gap-x-[14px]"
+          role="toolbar"
+          aria-label="Filter team by role"
+        >
+          {FILTER_TABS.map(({ label, roleType }) => {
+            const selected = selectedRoles.includes(roleType);
+            return (
+              <div key={roleType} className="contents">
+                <span className="max-md:contents md:hidden">
+                  <Filters
+                    title={label}
+                    state={selected ? "filled" : "outlined"}
+                    variant="dark"
+                    className="max-md:hover:!border-bp-white max-md:hover:!bg-bp-white/15"
+                    onClick={() => toggleRole(roleType)}
+                  />
+                </span>
+                <span className="hidden md:contents">
+                  <Filters
+                    title={label}
+                    variant="light"
+                    state={selected ? "selected" : "default"}
+                    onClick={() => toggleRole(roleType)}
+                  />
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div
+          className="grid w-full max-md:grid-cols-2 max-md:gap-3 max-md:justify-items-stretch justify-items-center gap-6 md:gap-8 md:[grid-template-columns:repeat(auto-fit,minmax(250px,1fr))]"
+          role="list"
+          aria-live="polite"
+        >
+          {displayedMembers.map((member) => (
+            <div
+              key={member.name}
+              className="flex w-full max-w-[350px] justify-center max-md:max-w-none"
+              role="listitem"
+            >
+              <MemberCard
+                name={member.name}
+                role={member.role}
+                roleType={member.roleType}
+                photoUrl={member.photoUrl}
+                linkedinUrl={member.linkedinUrl}
+                randomRotation
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-10 flex w-full justify-center max-md:mt-8 md:mt-12">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => navigate("/alumni")}
+            className="w-full md:hidden"
+          >
+            ALUMNI
+          </Button>
+          <Button
+            type="button"
+            variant="tertiary"
+            onClick={() => navigate("/alumni")}
+            className="hidden w-full desktop:h-[60px] desktop:w-[200px] desktop:min-w-[200px] desktop:max-w-[200px] desktop:shrink-0 desktop:px-4 md:flex"
+          >
+            ALUMNI
+          </Button>
+        </div>
+      </section>
     </PageContainer>
   );
 };


### PR DESCRIPTION
## Summary
Adds a **Meet the Team** section on the About page (filters, member grid, Alumni CTA) and fixes layout/stacking so **Our Values**, **InfoCards**, and **Meet the Team** don’t overlap on mobile or desktop. 

Also aligns About-related UI with `bp-*` design tokens and fixes polaroid frames that appeared transparent after the token migration.

---

## What Changed

### Meet the Team
- New section under **Our Values**
  - **Mobile**: full-width blue band (“our team”)
  - **Desktop**: grey card with “meet the team” (Caveat + custom size)
- Role filters
  - Mobile: dark variant
  - Desktop: light variant
- Member grid using `MemberCard`
- **ALUMNI → /alumni**
  - Mobile: secondary button
  - Desktop: tertiary button
- Temporary `TEAM_MEMBERS` placeholder data for review

---

### Layout & Stacking

#### Mobile
- Adjusted Values bottom spacing to prevent overlap with Meet section
- Fixed stacking order so Meet section doesn’t cover Values Rive
- Added `max-md:overflow-x-hidden` for proper full-bleed layout

#### Desktop
- Values wrapper updated:
  - `z-10` on mobile only
  - `md:z-0` on desktop
- Prevents Rive canvas from covering InfoCard text
- Maintains correct visual stacking across sections

---

### Design Tokens & Polaroids
- Migrated:
  - `blueprint-*` → `bp-*`
  - Includes InfoCard accents (`bp-blue`, `bp-orange`)
- Fixed polaroid frames:
  - `bg-bp-white` replaces invalid `bg-blueprint-white`
  - Prevented transparent frame issue
- Correct spacing utilities:
  - `md:pt-[20px]`
  - `md:pb-[24px]`

---

## How to Test

### Mobile (<768px)
- Values section is fully readable
- Meet section is full-width blue
- Filters, grid, and Alumni button display correctly

### Desktop (≥768px)
- InfoCards fully readable (including small body text)
- Values + Rive render correctly without overlap
- Meet section shows card layout with filters and grid

### Polaroids
- Frames are solid white (not transparent)
- New polaroids stack correctly on grid

### Filters
- Toggle roles correctly
- Empty selection shows full (sorted) roster

---

## Notes
- `TEAM_MEMBERS` is placeholder data only  
- Replace with real data source when available

## Screenshots
- Desktop:
<img width="975" height="816" alt="image" src="https://github.com/user-attachments/assets/085a79a4-d207-400e-8b4a-9f9e7e1bdcdd" />
- Mobile:
<img width="941" height="1252" alt="image" src="https://github.com/user-attachments/assets/6e230543-467c-4851-9273-fb44e68d4621" />
<img width="975" height="1215" alt="image" src="https://github.com/user-attachments/assets/fa510a72-c3d4-403f-ab17-5102be194b2a" />

Closes #99 