### PR TITLE
fix: complete Our Community Bikes project card data

### DIFF
--- a/src/constants/projects.ts
+++ b/src/constants/projects.ts
@@ -85,17 +85,18 @@ export const Projects = [
   {
     name: "Our Community Bikes",
     slug: "our-community-bikes",
-    status: "TEMP",
-    description: "TEMP",
+    status: "completed",
+    description:
+      "Reducing volunteer management time with a digital volunteer hour logbook.",
     date: "Feb - Nov 2024",
-    tags: ["TEMP"],
-    image: "TEMP",
-    popupimage: "TEMP",
+    tags: ["Community", "Admin"],
+    image: "/images/projects/our-community-bikes/logo.svg",
+    popupimage: "/images/projects/our-community-bikes/check-in-1.png",
     nonProfitDescription:
-      "PLACEHOLDER DESCRIPTION",
+      "Our Community Bikes is a Vancouver non-profit dedicated to providing bikes to underserved communities, empowering people to fix their own bikes, and increasing diversity in the repair industry.",
     projectDescription:
-      "PLACEHOLDER DESCRIPTION",
-    page: "PLACEHOLDER_LINK",
+      "SFU Blueprint built a web app to simplify volunteer hour tracking, reduce manual data entry, and help coordinators manage volunteer records more efficiently.",
+    page: "https://ourcommunitybikes.org/",
     team: OurCommunityBikes,
   },
 ];


### PR DESCRIPTION
- Completed the Our Community Bikes project card metadata in `projects.ts`
- Replaced `TEMP` placeholder values with real description, tags, image paths, and project details
- Confirmed the individual case study page works at `/projects/our-community-bikes`

## Why

The Our Community Bikes case study page and assets were already merged, but the Projects page entry still had placeholder values. This caused the project card to render incomplete/broken content on the projects page.

## How to Test

Run:

npm run dev

Then check:

- http://localhost:3000/projectspage
- http://localhost:3000/projects/our-community-bikes

Also ran:

npm run build