### PR TITLE
fix: show FooterRevamp on tablet and mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,9 +44,7 @@ function App() {
         <Route path="/projects/:slug" element={<IndividualProject />} />
       </Routes>
       </main>
-      <div className="hidden desktop:block">
-        <FooterRevamp />
-      </div>
+      <FooterRevamp />
     </div>
   );
 }


### PR DESCRIPTION
Remove hidden desktop:block wrapper in App so the footer renders at all breakpoints; FooterRevamp already handles responsive layouts internally.

Fixed missing footer on some viewports
<img width="500" height="5123" alt="screencapture-localhost-3000-projects-our-community-bikes-2026-05-13-15_03_31" src="https://github.com/user-attachments/assets/62c8fcaa-bdf2-45ab-ba44-263e0f9eac9f" />
