### PR TITLE
Ticket-84- fixed alignment for rive animation, loading in view and overflow for infocards

### DIFF
--- a/src/components/shared/InfoCard.tsx
+++ b/src/components/shared/InfoCard.tsx
@@ -13,8 +13,8 @@ export type InfoCardProps = {
 function InfoCard({ title, heading, body, color }: InfoCardProps) {
   return (
     <div
-      className="flex flex-col gap-6 bg-bp-white rounded-[5px] w-full max-w-[357px] h-[321px] px-7 pt-6 pb-12 
-      lg:max-w-[569px] lg:h-[382px] lg:px-12 lg:pt-9 lg:pb-16"
+      className="flex flex-col gap-6 bg-bp-white rounded-[5px] w-full min-w-[357px] h-[321px] px-7 pt-6 pb-12 
+      md:max-w-[569px] lg:h-[382px] lg:px-12 lg:pt-9 lg:pb-16"
     >
       {/* Gray Tag */}
       <div
@@ -31,12 +31,12 @@ function InfoCard({ title, heading, body, color }: InfoCardProps) {
       {/* Body Container */}
       <div className="gap-4 flex flex-col flex-1 min-w-[297px]">
         {/* Heading */}
-        <p className="font-['Poppins'] text-bp-black text-lg md:text-2xl leading-normal">
+        <p className="font-['Poppins'] text-bp-black text-lg lg:text-2xl leading-normal">
           {heading}
         </p>
 
         {/* Body */}
-        <p className="flex font-['Poppins'] text-bp-black text-sm md:text-base leading-normal">
+        <p className="flex font-['Poppins'] text-bp-black text-sm lg:text-base leading-normal">
           {body}
         </p>
       </div>

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import PageContainer from "../components/layout/PageContainer";
 import CameraButton from "../components/shared/CameraButton";
@@ -134,7 +134,6 @@ function pickRandomGridColumn(occupiedColumns: number[]): number {
 }
 
 const RIVE_VALUES_STATE_MACHINE = "MainStateMachine";
-
 /** Own hook instance + canvas; mount only one at a time so hidden WebGL canvases don’t break Rive. */
 function AboutValuesRiveDesktop() {
   const { RiveComponent } = useRive({
@@ -150,7 +149,7 @@ function AboutValuesRiveDesktop() {
   });
 
   return (
-    <RiveComponent className="h-[950px] w-[1200px] ml-[-400px] 2xl:ml-[-200px]" />
+    <RiveComponent className="h-[900px] lg:h-[950px] w-[1500px] ml-[-350px]" />
   );
 }
 
@@ -166,7 +165,7 @@ function AboutValuesRiveMobile() {
     }),
   });
 
-  return <RiveComponent className="relative h-[1000px] w-full translate-y-[-450px]" />;
+  return <RiveComponent className="h-[1100px] w-full translate-y-[-460px]" />;
 }
 
 const AboutPage = () => {
@@ -181,6 +180,31 @@ const AboutPage = () => {
 
     void Promise.all(images);
   }, []);
+
+  function useIsVisible(ref: React.RefObject<HTMLDivElement>) {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+      if (isVisible || !ref.current) return;
+      if (!ref.current) return;
+
+      const observer = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      });
+
+      observer.observe(ref.current);
+      return () => observer.disconnect();
+    }, [ref, isVisible]);
+
+    return isVisible;
+  }
+  
+  const isComponentVisible = useRef<HTMLDivElement>(null);
+  const isVisible = useIsVisible(isComponentVisible);
+  
 
   const INITIAL_VISIBLE = 3;
   const INITIAL_VISIBLE_MOBILE = 2;
@@ -339,7 +363,7 @@ const AboutPage = () => {
         </div>
 
         {/* Info Cards Container */}
-        <div className="relative z-10 md:pt-[108px] flex flex-col items-center justify-center gap-6 pb-[148px] lg:flex-row">
+        <div className="relative z-10 md:pt-[108px] flex flex-col items-center justify-center gap-6 mb-[148px] md:flex-row">
           <InfoCard
             title={OUR_MEMBERS_CONTENT.title}
             heading={OUR_MEMBERS_CONTENT.heading}
@@ -355,18 +379,24 @@ const AboutPage = () => {
           />
         </div>
 
-        {/* Values Section — Rive needs a real URL from Vite (?url) and a sized box for the canvas */}
-        <div className="relative z-10 w-full shrink-0 pb-[280px] max-md:pb-[420px] md:z-0 md:pb-0 max-md:overflow-hidden">
-          <div className="pointer-events-none relative z-10 flex flex-col md:gap-10 md:pb-[566px]">
-            <h2 className="pointer-events-auto flex flex-col max-md:justify-center max-md:items-center font-poppins text-5xl md:text-7xl md:ml-[-40px] 2xl:ml-[160px]">
-              our <strong>values</strong>
-            </h2>
+        
+  
+        <div ref={isComponentVisible} className="relative mb-[420px] md:left-1/2 md:translate-x-[calc(-50%+10vw)]">
+        {/* Header */}
+          <div className="pointer-events-none relative z-30 flex flex-col md:gap-10 mb-[280p]">
+              <h2 className="pointer-events-auto flex flex-col max-md:justify-center max-md:items-center font-poppins text-5xl 
+              md:text-7xl md:translate-x-[calc(-50%+35vw)] lg:translate-x-[calc(-50%+36vw)] 2xl:translate-x-[calc(-50%+51vw)] leading-10">
+                our <strong>values</strong>
+              </h2>
           </div>
-
-          <div className="absolute md:inset-x-0 bottom-0 z-0 h-[400px] w-full md:w-full md:h-[1000px] lg:translate-y-[-50px]">
-            {isMdUp ? <AboutValuesRiveDesktop /> : <AboutValuesRiveMobile />}
+          
+          {/* Rive */}
+          <div className="absolute w-full h-full bottom-0 md:translate-x-[calc(-50%+35vw)] 2xl:translate-x-[calc(-50%+50vw)] md:translate-y-[-300px] lg:translate-y-[-325px] ">
+            {isVisible ? (isMdUp ? <AboutValuesRiveDesktop /> : <AboutValuesRiveMobile />) : null}
           </div>
         </div>
+
+
       </div>
 
       {/* Meet the Team */}


### PR DESCRIPTION
## What Changed
1. Alignment of rive animation is centered and corrected as window size reduces
a. loads on scroll down so user sees animation
2. Fixed cards overflowing and flex size between the two cards

## Screenshots
XL
<img width="1888" height="919" alt="image" src="https://github.com/user-attachments/assets/0deed7bc-53e0-4b04-a193-22b1899531ed" />

window width 766px
<img width="766" height="891" alt="image" src="https://github.com/user-attachments/assets/5b427db2-4bbe-433b-9e9f-c42d267c0b0d" />

Window width 1015px
<img width="1015" height="841" alt="image" src="https://github.com/user-attachments/assets/979909f2-0af5-4402-ba8d-9cea748b758f" />

## Notes and How to test
Suggest to change browser window size to test responsive design
https://blueprint-website-v2-tawny.vercel.app?_vercel_share=lYwnUICJw9wN7MEQ9adf6PdtmE0x3Vk0

Notes:
Rive component loads on user view, but I suggest creating an 'initial' state before 'State 1'. The Rive animation loads the first state, 'State 1' which displays the first value right away. A state that previews the load animation would improve the on view function. 