### PR TITLE
interactive sponsor cards and legal page typography updates

### DIFF
--- a/src/components/legal/CrosspointTitle.tsx
+++ b/src/components/legal/CrosspointTitle.tsx
@@ -57,7 +57,7 @@ export default function CrosspointTitle({ lines }: CrosspointTitleProps) {
 
       <h1
         ref={titleRef}
-        className="relative z-10 m-0 text-left font-poppins text-[78px] font-medium leading-[85%] tracking-[-1.56px] text-bp-black max-md:text-[46px] max-md:tracking-[-0.92px]"
+        className="relative z-10 m-0 text-left font-poppins text-[58px] font-medium leading-[85%] tracking-[-1.16px] text-bp-black max-md:text-[34px] max-md:tracking-[-0.68px]"
       >
         <span className="block">
           {lines[0]}

--- a/src/components/legal/LegalPageLayout.tsx
+++ b/src/components/legal/LegalPageLayout.tsx
@@ -42,7 +42,7 @@ export default function LegalPageLayout({
               }`}
             >
               {section.heading && (
-                <h2 className="m-0 font-poppins text-[30px] font-semibold leading-[100%] tracking-[-0.6px] text-bp-black">
+                <h2 className="m-0 font-poppins text-[24px] font-semibold leading-[130%] tracking-[-0.48px] text-bp-black max-md:text-[20px] max-md:tracking-[-0.4px]">
                   {section.heading}
                 </h2>
               )}
@@ -60,7 +60,7 @@ export default function LegalPageLayout({
           ))}
 
           <section className="mt-[50px] flex flex-col items-start self-stretch gap-[12px]">
-            <h2 className="m-0 font-poppins text-[78px] font-medium leading-[85%] tracking-[-1.56px] text-bp-black">
+            <h2 className="m-0 font-poppins text-[58px] font-medium leading-[85%] tracking-[-1.16px] text-bp-black max-md:text-[34px] max-md:tracking-[-0.68px]">
               {contactHeading}
             </h2>
 

--- a/src/components/shared/ExpandableContentCards.tsx
+++ b/src/components/shared/ExpandableContentCards.tsx
@@ -1,0 +1,61 @@
+export type ExpandableContentCard = {
+  title: string;
+  body: string;
+  image: string;
+  imageAlt?: string;
+  imageClassName: string;
+  imageHoverClassName?: string;
+  accentColor: string;
+};
+
+type ExpandableContentCardsProps = {
+  cards: readonly ExpandableContentCard[];
+  showMobileIndicators?: boolean;
+};
+
+export default function ExpandableContentCards({
+  cards,
+  showMobileIndicators = true,
+}: ExpandableContentCardsProps) {
+  return (
+    <div className="w-full max-md:w-[351px]">
+      <div className="flex justify-center gap-[23px] max-md:snap-x max-md:justify-start max-md:overflow-x-auto max-md:scrollbar-hide-custom">
+        {cards.map((card) => (
+          <article
+            key={card.title}
+            className="group/expandable-card relative h-[470px] w-[351px] shrink-0 overflow-hidden rounded-[10px] bg-white px-9 pt-9 transition-[width] duration-300 ease-out md:hover:w-[429px] max-md:h-[418px] max-md:snap-center motion-reduce:transition-none"
+          >
+            <div className="flex items-center gap-0 transition-[gap] duration-300 ease-out md:group-hover/expandable-card:gap-[10px] motion-reduce:transition-none">
+              <span
+                className="h-[19px] w-0 shrink-0 rounded-[4px] opacity-0 transition-[width,opacity] duration-300 ease-out md:group-hover/expandable-card:w-[19px] md:group-hover/expandable-card:opacity-100 motion-reduce:transition-none"
+                style={{ backgroundColor: card.accentColor }}
+                aria-hidden
+              />
+              <h3 className="whitespace-nowrap font-caveat text-[32px] font-normal leading-[1.3] tracking-[-0.64px] text-black max-md:text-[28px] max-md:tracking-[-0.56px]">
+                {card.title}
+              </h3>
+            </div>
+            <p className="mt-[10px] w-[282px] font-poppins text-[16px] font-normal leading-normal text-black transition-[width] duration-300 ease-out md:group-hover/expandable-card:w-[275px] max-md:w-[290px] max-md:text-[14px] motion-reduce:transition-none">
+              {card.body}
+            </p>
+            <div className="absolute left-5 top-[199px] h-[252px] w-[312px] overflow-hidden rounded-[10px] transition-[left,width] duration-300 ease-out md:group-hover/expandable-card:left-[20.5px] md:group-hover/expandable-card:w-[392px] max-md:top-[145px] motion-reduce:transition-none">
+              <img
+                src={card.image}
+                alt={card.imageAlt ?? ""}
+                className={`absolute max-w-none transition-[left,width] duration-300 ease-out motion-reduce:transition-none ${card.imageClassName} ${card.imageHoverClassName ?? ""}`}
+                loading="lazy"
+              />
+            </div>
+          </article>
+        ))}
+      </div>
+      {showMobileIndicators && (
+        <div className="mt-[22px] hidden justify-center gap-[8px] max-md:flex" aria-hidden>
+          <span className="h-[11px] w-[30px] rounded-full bg-bp-blue" />
+          <span className="size-[11px] rounded-full bg-bp-grey" />
+          <span className="size-[11px] rounded-full bg-bp-grey" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/SponsorUsPage.tsx
+++ b/src/pages/SponsorUsPage.tsx
@@ -1,28 +1,29 @@
+import ExpandableContentCards from "../components/shared/ExpandableContentCards";
 
 const FUNDING_CARDS = [
   {
     title: "Workshops & Learning",
-    description:
-      "So every Blueprint member leaves sessions more skilled than when they arrived.",
-    imageSrc: "/images/sponsor/workshops-learning.jpg",
+    body: "So every Blueprint member leaves sessions more skilled than when they arrived.",
+    image: "/images/sponsor/workshops-learning.jpg",
     imageAlt: "Blueprint members attending a workshop.",
-    imageClassName: "object-bottom",
+    imageClassName: "h-full w-full object-cover object-bottom",
+    accentColor: "#D2A6FB",
   },
   {
     title: "Project Maintenance",
-    description:
-      "Servers and hosting that make sure the software we build stays live for the NPOs who depend on it.",
-    imageSrc: "/images/sponsor/project-maintenance.jpg",
+    body: "Servers and hosting that make sure the software we build stays live for the NPOs who depend on it.",
+    image: "/images/sponsor/project-maintenance.jpg",
     imageAlt: "A Blueprint project repository dashboard.",
-    imageClassName: "object-left-top",
+    imageClassName: "h-full w-full object-cover object-left-top",
+    accentColor: "#F49F00",
   },
   {
     title: "Equipping our Team",
-    description:
-      "Tools and software that help our developers, designers, and PMs do their best work.",
-    imageSrc: "/images/sponsor/equipping-team.jpg",
+    body: "Tools and software that help our developers, designers, and PMs do their best work.",
+    image: "/images/sponsor/equipping-team.jpg",
     imageAlt: "Blueprint team members working together.",
-    imageClassName: "object-[center_28%]",
+    imageClassName: "h-full w-full object-cover object-[center_28%]",
+    accentColor: "#A5C6FF",
   },
 ] as const;
 
@@ -145,34 +146,6 @@ function SponsorshipCalloutCard(
   )
 }
 
-function FundingCard({
-  title,
-  description,
-  imageSrc,
-  imageAlt,
-  imageClassName,
-}: (typeof FUNDING_CARDS)[number]) {
-  return (
-    <li className="relative h-[470px] w-[351px] max-w-full shrink-0 overflow-hidden rounded-[10px] bg-white px-9 pb-[19px] pt-9 max-[390px]:h-auto max-[390px]:px-5 max-[390px]:pb-5">
-      <div className="flex max-w-[282px] flex-col gap-[10px]">
-        <h3 className="font-caveat text-[32px] leading-[1.3] tracking-[-0.64px] text-black max-[390px]:text-[28px]">
-          {title}
-        </h3>
-        <p className="font-poppins text-body-m-reg text-black">{description}</p>
-      </div>
-      <div className="absolute bottom-[19px] left-5 h-[252px] w-[312px] max-w-[calc(100%-40px)] overflow-hidden rounded-[10px] max-[390px]:relative max-[390px]:bottom-auto max-[390px]:left-auto max-[390px]:mt-8 max-[390px]:h-[220px] max-[390px]:w-full max-[390px]:max-w-none">
-        <img
-          src={imageSrc}
-          alt={imageAlt}
-          className={`h-full w-full object-cover ${imageClassName}`}
-        />
-      </div>
-    </li>
-  );
-}
-
-
-
 export default function SponsorUsPage() {
   return (
     <div className="w-full overflow-x-hidden bg-bp-lightest-grey font-poppins text-bp-black">
@@ -198,11 +171,7 @@ export default function SponsorUsPage() {
           <h2 className="text-center font-poppins text-heading-s-reg text-black max-md:text-mobile-heading-s-reg">
             what will we <span className="font-semibold">use funds</span> for?
           </h2>
-          <ul className="flex w-full justify-center gap-[23px] max-[1160px]:flex-col max-[1160px]:items-center">
-            {FUNDING_CARDS.map((card) => (
-              <FundingCard key={card.title} {...card} />
-            ))}
-          </ul>
+          <ExpandableContentCards cards={FUNDING_CARDS} />
         </div>
       </section>
 

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useLayoutEffect, useRef, useState, type ComponentType, type CSSProperties, type SVGProps } from "react";
 import Button from "../components/shared/Button";
+import ExpandableContentCards from "../components/shared/ExpandableContentCards";
 import { ReactComponent as ArrowUpRightIcon } from "../assets/icons/ArrowUpRight.svg";
 import { ReactComponent as InstagramIcon } from "../assets/icons/instagram.svg";
 import { ReactComponent as YoutubeIcon } from "../assets/icons/youtube.svg";
@@ -38,7 +39,7 @@ const SOCIAL_EVENT_CARDS = [
     image: "/images/student/join-social-blueprint-wide.webp",
     imageClassName: "h-[166.67%] w-[179.49%] -left-[32.67%] -top-[66.67%]",
     accentColor: "#D2A6FB",
-    imageHoverClassName: "md:group-hover/social-card:left-[-17.35%] md:group-hover/social-card:w-[142.86%]",
+    imageHoverClassName: "md:group-hover/expandable-card:left-[-17.35%] md:group-hover/expandable-card:w-[142.86%]",
   },
   {
     title: "Team Socials",
@@ -209,7 +210,7 @@ function TypicalExperienceSection() {
         <p className="max-w-[820px] text-center font-poppins text-[24px] font-normal leading-[1.3] tracking-[-0.48px] text-black max-md:max-w-[300px] max-md:text-[18px] max-md:tracking-[-0.36px]">
           Through our <span className="font-medium">regular social events</span>, you can take the opportunity to meet passionate people, build real connections, and engage with a community that supports your growth - personally and professionally.
         </p>
-        <SocialEventCards />
+        <ExpandableContentCards cards={SOCIAL_EVENT_CARDS} />
       </div>
 
       <TimelineSection />
@@ -314,48 +315,6 @@ function TriadRoleButton({
       <span className="size-4 shrink-0 rounded-[3px] max-md:size-3" style={{ backgroundColor: accent }} aria-hidden />
       {label}
     </button>
-  );
-}
-
-function SocialEventCards() {
-  return (
-    <div className="w-full max-md:w-[351px]">
-      <div className="flex justify-center gap-[23px] max-md:snap-x max-md:justify-start max-md:overflow-x-auto max-md:scrollbar-hide-custom">
-        {SOCIAL_EVENT_CARDS.map((card) => (
-          <article
-            key={card.title}
-            className="group/social-card relative h-[470px] w-[351px] shrink-0 overflow-hidden rounded-[10px] bg-white px-9 pt-9 transition-[width] duration-300 ease-out md:hover:w-[429px] max-md:h-[418px] max-md:snap-center motion-reduce:transition-none"
-          >
-            <div className="flex items-center gap-0 transition-[gap] duration-300 ease-out md:group-hover/social-card:gap-[10px] motion-reduce:transition-none">
-              <span
-                className="h-[19px] w-0 shrink-0 rounded-[4px] opacity-0 transition-[width,opacity] duration-300 ease-out md:group-hover/social-card:w-[19px] md:group-hover/social-card:opacity-100 motion-reduce:transition-none"
-                style={{ backgroundColor: card.accentColor }}
-                aria-hidden
-              />
-              <h3 className="whitespace-nowrap font-caveat text-[32px] font-normal leading-[1.3] tracking-[-0.64px] text-black max-md:text-[28px] max-md:tracking-[-0.56px]">
-                {card.title}
-              </h3>
-            </div>
-            <p className="mt-[10px] w-[282px] font-poppins text-[16px] font-normal leading-normal text-black transition-[width] duration-300 ease-out md:group-hover/social-card:w-[275px] max-md:w-[290px] max-md:text-[14px] motion-reduce:transition-none">
-              {card.body}
-            </p>
-            <div className="absolute left-5 top-[199px] h-[252px] w-[312px] overflow-hidden rounded-[10px] transition-[left,width] duration-300 ease-out md:group-hover/social-card:left-[20.5px] md:group-hover/social-card:w-[392px] max-md:top-[145px] motion-reduce:transition-none">
-              <img
-                src={card.image}
-                alt=""
-                className={`absolute max-w-none transition-[left,width] duration-300 ease-out motion-reduce:transition-none ${card.imageClassName} ${card.imageHoverClassName ?? ""}`}
-                loading="lazy"
-              />
-            </div>
-          </article>
-        ))}
-      </div>
-      <div className="mt-[22px] hidden justify-center gap-[8px] max-md:flex" aria-hidden>
-        <span className="h-[11px] w-[30px] rounded-full bg-bp-blue" />
-        <span className="size-[11px] rounded-full bg-bp-grey" />
-        <span className="size-[11px] rounded-full bg-bp-grey" />
-      </div>
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Add interactive hover/expand card behavior to the Sponsor Us **"What Will We Use Funds For?"** section, matching the Students page social event cards.
- Extract a shared `ExpandableContentCards` component and refactor the Students page to use it.
- Tune legal page typography:
  - Page title and **Contact** heading: `58px` desktop / `34px` mobile, font weight `500`.
  - Section headings: `24px` desktop / `20px` mobile.

## Test Plan

- Visit `/sponsor-us` and hover over funding cards on desktop:
  - Card expands.
  - Accent pill appears.
  - Image widens smoothly.
- Verify funding cards use horizontal snap scrolling on mobile and tablet.
- Visit `/students` and confirm social event cards still behave as expected.
- Visit `/privacy-policy` and `/terms-and-conditions`:
  - Verify page title sizing.
  - Verify section heading sizing.
  - Verify Contact heading sizing.
- Confirm there is no layout shift during card hover animations.
- Run:

## Preview:
https://blueprint-website-v2-git-feature-spo-d9a1fa-bandoozles-projects.vercel.app/sponsor-us

## Closes #144 