### PR TITLE
Ticket 148 Update Students Page + NPO Our Approach

### DIFF
--- a/src/components/shared/Accordion.tsx
+++ b/src/components/shared/Accordion.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import AccordionChevron from "./AccordionChevron";
+import type { CSSProperties } from "react";
 
 type AccordionProps = {
   header: React.ReactNode;
@@ -15,21 +16,26 @@ export default function Accordion({
   className = "",
 }: AccordionProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
+  const childRef = useRef(null)
+  const [childSize, setChildSize] = useState(400)
+
+  // Calculates child height and stores in state
+  useEffect(() => {
+    setChildSize(childRef.current.scrollHeight)
+  }, [children])
+
+  const SizeVarStyle: CSSProperties = {'--custSize': `${childSize}px` } as CSSProperties
 
   return (
     <div
       className={`bg-white rounded-[5px] overflow-hidden font-poppins w-full flex flex-col
-        ${isOpen
-          ? "gap-[6px] md:gap-[12px] pb-[30px] md:pb-[60px]"
-          : ""
-        }
         ${className}`}
     >
       {/* Header row — always visible */}
       <div 
         className={`flex items-center justify-between w-full hover:bg-gray-50 
           ${isOpen 
-            ? 'p-[18px] md:pt-[24px] md:px-[36px] ' 
+            ? 'p-[24px] md:pt-[24px] md:px-[36px] ' 
             : 'p-[18px] md:px-[36px] md:py-[24px]'}`
           }
           onClick={() => setIsOpen((prev) => !prev)}>
@@ -46,13 +52,21 @@ export default function Accordion({
       </div>
 
       {/* Body — shown when open */}
-      {isOpen && (
-        <div className="w-full shrink-0 md:pr-[90px] md:px-[36px] px-[18px]">
-          <div className="text-bp-black font-normal leading-normal text-[14px] md:text-[16px]">
-            {children}
-          </div>
+      <div 
+        className={`w-full shrink-0 md:pr-[90px] md:px-[36px] px-[18px] overflow-hidden transition-all 
+          duration-300 ease-in-out
+          ${isOpen 
+            ? `max-h-[var(--custSize)] opacity-100` 
+            : 'max-h-0 opacity-0'}`
+          }
+        style={{...SizeVarStyle }}
+          >
+        <div className="text-bp-black font-normal leading-normal text-[14px] md:text-[16px] pb-[30px] md:pb-[60px] pt-[6px] md:pt-[12px]"
+          ref={childRef}>
+          {children}
         </div>
-      )}
+      </div>
+      
     </div>
   );
 }

--- a/src/components/shared/Accordion.tsx
+++ b/src/components/shared/Accordion.tsx
@@ -20,13 +20,19 @@ export default function Accordion({
     <div
       className={`bg-white rounded-[5px] overflow-hidden font-poppins w-full flex flex-col
         ${isOpen
-          ? "pt-[18px] px-[18px] pb-[30px] gap-[24px] md:pt-[24px] md:px-[36px] md:pb-[60px] md:gap-[30px]"
-          : "p-[18px] md:px-[36px] md:py-[24px]"
+          ? "gap-[6px] md:gap-[12px] pb-[30px] md:pb-[60px]"
+          : ""
         }
         ${className}`}
     >
       {/* Header row — always visible */}
-      <div className="flex items-center justify-between w-full">
+      <div 
+        className={`flex items-center justify-between w-full hover:bg-gray-50 
+          ${isOpen 
+            ? 'p-[18px] md:pt-[24px] md:px-[36px] ' 
+            : 'p-[18px] md:px-[36px] md:py-[24px]'}`
+          }
+          onClick={() => setIsOpen((prev) => !prev)}>
         <span
           className="text-bp-black font-medium leading-[1.3]
             text-[18px] tracking-[-0.36px]
@@ -36,13 +42,12 @@ export default function Accordion({
         </span>
         <AccordionChevron
           isOpen={isOpen}
-          onClick={() => setIsOpen((prev) => !prev)}
         />
       </div>
 
       {/* Body — shown when open */}
       {isOpen && (
-        <div className="w-full shrink-0 md:pr-[90px]">
+        <div className="w-full shrink-0 md:pr-[90px] md:px-[36px] px-[18px]">
           <div className="text-bp-black font-normal leading-normal text-[14px] md:text-[16px]">
             {children}
           </div>

--- a/src/components/shared/AccordionChevron.tsx
+++ b/src/components/shared/AccordionChevron.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 type AccordionChevronProps = {
   isOpen: boolean;
-  onClick: () => void;
+  onClick?: () => void;
   className?: string;
 };
 

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -477,10 +477,10 @@ function ApplicationProcessSection() {
 
 function InfoSessionCard() {
   return (
-    <article className="flex min-h-[278px] flex-col gap-8 rounded-[10px] bg-bp-lighter-grey p-12 max-md:min-h-[390px] max-md:px-6 max-md:py-12">
-      <div className="flex flex-col gap-3 max-md:gap-[23px]">
-        <div className="flex items-start justify-between gap-8 max-md:flex-col max-md:gap-[23px]">
-          <div className="flex w-[366px] flex-col gap-1 text-bp-black max-md:w-full">
+    <article className="flex min-h-[278px] flex-col md:flex-row gap-8 rounded-[10px] bg-bp-lighter-grey p-12 max-md:min-h-[390px] max-md:px-6 max-md:py-12">
+      <div className="flex flex-col md:flex-row gap-3 max-md:gap-[23px] md:w-[clamp(1px,1000px,600px)]">
+        <div className="flex flex-col items-start max-md:justify-between gap-8 max-md:gap-[23px] md:mr-auto ">
+          <div className="flex max-w-[366px] flex-col gap-1 text-bp-black max-md:w-full">
             <p className="font-poppins text-[14px] font-medium uppercase leading-normal max-md:text-[10px]">
               upcoming event:
             </p>
@@ -492,10 +492,11 @@ function InfoSessionCard() {
             RSVP
           </Button>
         </div>
-        <div className="h-px w-full bg-black/10" />
+        <div className="w-full h-[1px] md:hidden bg-black/10"/>
+        <div className="w-[1px] h-100 max-md:hidden bg-black/10"/>
       </div>
 
-      <div className="flex gap-[52px] font-poppins text-bp-black max-md:flex-col max-md:gap-4">
+      <div className="flex flex-col md:justify-around  max-md:gap-4 font-poppins text-bp-black">
         <EventDetail label="DATE AND TIME:" value="September 10, 2026, 7 PM" />
         <EventDetail label="LOCATION:" value="SFU Burnaby Campus, ASB 9720" />
       </div>
@@ -506,8 +507,8 @@ function InfoSessionCard() {
 function EventDetail({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex w-[253px] flex-col gap-[10px] max-md:gap-1.5">
-      <p className="text-[14px] font-medium uppercase leading-normal max-md:text-[10px]">{label}</p>
-      <p className="text-[16px] font-normal leading-normal max-md:text-[14px]">{value}</p>
+      <p className="text-[14px] md:text-body-s-reg uppercase text-mobile-body-s-reg ">{label}</p>
+      <p className="text-[16px] md:text-body-m-reg text-mobile-body-m-reg">{value}</p>
     </div>
   );
 }

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -184,13 +184,6 @@ function HeroSection({ onOpenPositions }: { onOpenPositions: () => void }) {
               {HERO_CONTENT.subtitle}
             </p>
           </div>
-          <Button
-            variant="tertiary"
-            onClick={onOpenPositions}
-            className="mt-[138px] mr-[34px] w-[200px] max-md:mr-0 max-md:mt-0 max-md:h-[52px] max-md:w-full max-md:text-[14px]"
-          >
-            OPEN POSITIONS
-          </Button>
         </div>
 
         <div className="mt-[60px] w-full max-w-[617px] rounded-[5px] bg-white p-9 max-md:mt-[67px] max-md:px-[30px] max-md:pb-12 max-md:pt-7">
@@ -208,6 +201,13 @@ function HeroSection({ onOpenPositions }: { onOpenPositions: () => void }) {
               <li key={bullet}>{bullet}</li>
             ))}
           </ul>
+          <Button
+            variant="primary"
+            onClick={onOpenPositions}
+            className="mt-12 mr-[34px] w-[200px] max-md:mr-0 max-md:mt-9 max-md:h-[52px] max-md:w-full max-md:text-[14px]"
+          >
+            SEE OPEN POSITIONS
+          </Button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## What Changed
- Moved and re-titled open positions button on students
- Updated Event component to match new design on students
- Added animations to NPO 'Our Approach' section and made entire bar clickable

## Screenshots
<img width="762" height="557" alt="ticket-148-Students-CTA" src="https://github.com/user-attachments/assets/3c1d4245-f3ac-43a2-b3cb-dce2b0483ba7" />
Student CTA

<img width="1251" height="437" alt="ticket-148-new-event-card" src="https://github.com/user-attachments/assets/5169d9ab-add2-47d8-a273-a4a3772353dc" />
New design for event

<img width="647" height="445" alt="ticket-148-mobile-event-card" src="https://github.com/user-attachments/assets/86459c29-3df9-4e4c-88ec-fd32a62dc4b6" />
Mobile design stays the same

## How to Test
run `npm run dev` in your terminal and examine changes on students page and animations in NPO 'our approach',
Alternatively preview at https://blueprint-website-v2-nine.vercel.app/

Students:
- CTA component button placement
- Event card at md breakpoint and larger

NPO
- Accordian header hover click
- Accordian children animation

## Additional Notes
- Design for events was kept the same for mobile. Keeping new design on mobile would have involved changing the button component for mobile.

Closes #148 