### PR TITLE
Ticket 150: Update 'Non-profit' page crosspoint

### DIFF
--- a/src/pages/NonprofitsPage.tsx
+++ b/src/pages/NonprofitsPage.tsx
@@ -33,7 +33,7 @@ const NonprofitsPage = () => {
                       max-[1279.9px]:right-[-217px]
                       max-[1023.9px]:right-[-216px]
                       max-[767.9px]:right-[-234px] max-[767.9px]:top-[-65px] md:scale-[1.6] max-md:scale-[0.8]                     min-[514px]:w-[500px] max-[513.9px]:w-[300px] max-[513.9px]:scale-[1] max-[513.9px]:right-[-100px] max-[513.9px]:top-[-25px]
-                      max-[513.9px]:scale-[0.9] max-[513.9px]:right-[-150px] max-[513.9px]:top-[50px]
+                      max-[513.9px]:scale-[0.9] max-[513.9px]:right-[-155px] max-[513.9px]:top-[50px]
                       absolute  z-[-10]">
             <source src="videos/crosspoints/dotted-path-1.webm" type="video/webm"/>
           </video>

--- a/src/pages/NonprofitsPage.tsx
+++ b/src/pages/NonprofitsPage.tsx
@@ -13,11 +13,12 @@ const NonprofitsPage = () => {
     >
       <div className="w-full h-0 xl:ml-[-144px] max-[1279.9px]:ml-[-40px]">
           <div className="bg-bp-lightest-grey bg-[url('/images/crosspoint.png')] bg-no-repeat z-[-10]
-                    min-[1340px]:bg-[calc(100%+600px)_-390px]
-                    max-[1339.9px]:bg-[calc(100%+670px)_-390px]
-                    max-[1279.9px]:bg-[calc(100%+630px)_-390px]
-                    max-[1023.9px]:bg-[calc(100%+700px)_-390px]
-                    max-[767.9px]:bg-[calc(100%+683px)_-480px] max-[767.9px]:w-[calc(100%+17px)]
+                    min-[1340px]:bg-[calc(100%+600px)_-385px]
+                    max-[1339.9px]:bg-[calc(100%+670px)_-385px]
+                    max-[1279.9px]:bg-[calc(100%+700px)_-385px]
+                    max-[1023.9px]:bg-[calc(100%+700px)_-385px]
+                    max-[767.9px]:bg-[calc(100%+715px)_-420px] max-[767.9px]:w-[calc(100%+17px)]
+                    max-[513.9px]:bg-[calc(100%+745px)_-470px]
                     overflow-clip w-full h-full mt-[-110px] absolute ">
 
           </div>
@@ -27,13 +28,12 @@ const NonprofitsPage = () => {
             loop
             playsInline
             className="
-                      min-[1340px]:right-[-117px] min-[1340px]:top-[-50px]
-                      max-[1339.9px]:right-[-187px] max-[1339.9px]:top-[-40px]
-                      max-[1279.9px]:right-[-147px]
+                      min-[1340px]:right-[-117px] min-[1340px]:top-[-45px]
+                      max-[1339.9px]:right-[-187px] max-[1339.9px]:top-[-35px]
+                      max-[1279.9px]:right-[-217px]
                       max-[1023.9px]:right-[-216px]
-                      max-[767.9px]:scale-[0.6] max-[767.9px]:right-[-202px] max-[767.9px]:top-[-125px]
-                      min-[514px]:w-[500px] max-[513.9px]:w-[300px] max-[513.9px]:scale-[1] max-[513.9px]:right-[-100px] max-[513.9px]:top-[-25px]
-
+                      max-[767.9px]:right-[-234px] max-[767.9px]:top-[-65px] md:scale-[1.6] max-md:scale-[0.8]                     min-[514px]:w-[500px] max-[513.9px]:w-[300px] max-[513.9px]:scale-[1] max-[513.9px]:right-[-100px] max-[513.9px]:top-[-25px]
+                      max-[513.9px]:scale-[0.9] max-[513.9px]:right-[-150px] max-[513.9px]:top-[50px]
                       absolute  z-[-10]">
             <source src="videos/crosspoints/dotted-path-1.webm" type="video/webm"/>
           </video>


### PR DESCRIPTION
## What Changed
- Updated NPO page crosspoints. This involved scaling the image at different breakpoints and translating the components.

## Screenshots
<img width="1787" height="876" alt="ticket-150-desktop" src="https://github.com/user-attachments/assets/2c46d52b-6cd5-4dc2-ae24-140483114f18" />
Desktop: Image is bigger and is properly aligned with '__can your idea become a project__' section.
<img width="742" height="721" alt="ticket-150-tablet" src="https://github.com/user-attachments/assets/1b704cf7-477d-4545-b600-3cf68d2a027d" />
Tablet: Has its own size from mobile and follows desktop placement.
<img width="437" height="732" alt="ticket-
150-mobile" src="https://github.com/user-attachments/assets/f75c99ea-1a73-4fc3-a94b-1095039a1814" />

Mobile: Crosspoint '+' no longer visible. Video is cut off horizontally at center by viewport

## How to Test
run npm run dev terminal and exampine NPO page crosspoints animation at Desktop, Tablet, and Mobile breakpoints.
Alternatively preview at https://blueprint-website-v2-nine.vercel.app/

## Additional Notes
- The video when scaled down for mobile looks a bit pixelated and does match how bubbly the background looks on the figma.

Closes #150 