### PR TITLE
fix: Students Social Cards updated to hover on card

### DIFF
--- a/src/components/shared/ExpandableContentCards.tsx
+++ b/src/components/shared/ExpandableContentCards.tsx
@@ -19,26 +19,26 @@ export default function ExpandableContentCards({
 }: ExpandableContentCardsProps) {
   return (
     <div className="w-full max-md:w-[351px]">
-      <div className="flex justify-center gap-[23px] max-md:snap-x max-md:justify-start max-md:overflow-x-auto max-md:scrollbar-hide-custom">
+      <div className="flex justify-center gap-[23px] max-lg:snap-x max-lg:justify-start max-lg:overflow-x-auto max-lg:scrollbar-hide-custom">
         {cards.map((card) => (
           <article
             key={card.title}
-            className="group/expandable-card relative h-[470px] w-[351px] shrink-0 overflow-hidden rounded-[10px] bg-white px-9 pt-9 transition-[width] duration-300 ease-out md:hover:w-[429px] max-md:h-[418px] max-md:snap-center motion-reduce:transition-none"
+            className="group/expandable-card relative h-[470px] w-[351px] shrink-0 overflow-hidden rounded-[10px] bg-white px-9 pt-9 transition-[width] duration-300 ease-out lg:hover:w-[429px] max-lg:snap-center motion-reduce:transition-none"
           >
-            <div className="flex items-center gap-0 transition-[gap] duration-300 ease-out md:group-hover/expandable-card:gap-[10px] motion-reduce:transition-none">
+            <div className="flex items-center gap-0 transition-[gap] duration-300 ease-out lg:group-hover/expandable-card:gap-[10px] motion-reduce:transition-none">
               <span
-                className="h-[19px] w-0 shrink-0 rounded-[4px] opacity-0 transition-[width,opacity] duration-300 ease-out md:group-hover/expandable-card:w-[19px] md:group-hover/expandable-card:opacity-100 motion-reduce:transition-none"
+                className="h-[19px] w-0 shrink-0 rounded-[4px] opacity-0 transition-[width,opacity] duration-300 ease-out lg:group-hover/expandable-card:w-[19px] lg:group-hover/expandable-card:opacity-100 motion-reduce:transition-none"
                 style={{ backgroundColor: card.accentColor }}
                 aria-hidden
               />
-              <h3 className="whitespace-nowrap font-caveat text-[32px] font-normal leading-[1.3] tracking-[-0.64px] text-black max-md:text-[28px] max-md:tracking-[-0.56px]">
+              <h3 className="whitespace-nowrap font-caveat text-[32px] font-normal leading-[1.3] tracking-[-0.64px] text-black">
                 {card.title}
               </h3>
             </div>
-            <p className="mt-[10px] w-[282px] font-poppins text-[16px] font-normal leading-normal text-black transition-[width] duration-300 ease-out md:group-hover/expandable-card:w-[275px] max-md:w-[290px] max-md:text-[14px] motion-reduce:transition-none">
+            <p className="mt-[10px] w-[282px] font-poppins text-[16px] font-normal leading-normal text-black transition-[width] duration-300 ease-out lg:group-hover/expandable-card:w-[275px] motion-reduce:transition-none">
               {card.body}
             </p>
-            <div className="absolute left-5 top-[199px] h-[252px] w-[312px] overflow-hidden rounded-[10px] transition-[left,width] duration-300 ease-out md:group-hover/expandable-card:left-[20.5px] md:group-hover/expandable-card:w-[392px] max-md:top-[145px] motion-reduce:transition-none">
+            <div className="absolute left-5 top-[199px] h-[252px] w-[312px] overflow-hidden rounded-[10px] transition-[left,width] duration-300 ease-out lg:group-hover/expandable-card:left-[20.5px] lg:group-hover/expandable-card:w-[392px] motion-reduce:transition-none">
               <img
                 src={card.image}
                 alt={card.imageAlt ?? ""}
@@ -50,7 +50,7 @@ export default function ExpandableContentCards({
         ))}
       </div>
       {showMobileIndicators && (
-        <div className="mt-[22px] hidden justify-center gap-[8px] max-md:flex" aria-hidden>
+        <div className="mt-[22px] hidden justify-center gap-[8px] max-lg:flex" aria-hidden>
           <span className="h-[11px] w-[30px] rounded-full bg-bp-blue" />
           <span className="size-[11px] rounded-full bg-bp-grey" />
           <span className="size-[11px] rounded-full bg-bp-grey" />

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -157,7 +157,7 @@ function HeroSection({ onOpenPositions }: { onOpenPositions: () => void }) {
                   min-[1280px]:bg-[calc(50%+35px)_-388px]
                   max-[1279.9px]:bg-[calc(100%+615px)_-388px]
                   max-[767.9px]:bg-[calc(100%+615px)_-500px] max-[767.9px]:w-[calc(100%+17px)]
-                  overflow-clip w-full h-full mt-[-110px] absolute z-10">
+                  overflow-clip w-full h-full mt-[-110px] absolute z-10 pointer-events-none">
 
         </div>
         <video
@@ -170,7 +170,7 @@ function HeroSection({ onOpenPositions }: { onOpenPositions: () => void }) {
                     max-[1279.9px]:right-[-320px] max-[1279.9px]:top-[-185px]
                     max-[1023.9px]:right-[-235px] max-[1023.9px]:top-[-100px] min-[1024px]:w-[790px] max-[1023.9px]:w-[620px]
                     max-[767.9px]:right-[-200px] max-[767.9px]:top-[-285px]
-                    absolute z-0">
+                    absolute z-0 pointer-events-none">
           <source src="videos/crosspoints/dotted-path-2.webm" type="video/webm"/>
         </video>
       </div>
@@ -633,7 +633,7 @@ function StayUpdatedSection() {
           <div className="bg-bp-lightest-grey bg-[url('/images/crosspoint.png')] bg-no-repeat
                     min-[768px]:bg-[calc(50%-399px)_-310px] 
                     max-[767.9px]:bg-[calc(50%-190px)_-250px] max-[767.9px]:bg-[length:1100px_1100px]
-                    overflow-clip h-[900px] w-full mt-[-110px] absolute">
+                    overflow-clip h-[900px] w-full mt-[-110px] absolute pointer-events-none">
           </div>
           <video
             autoPlay
@@ -643,7 +643,7 @@ function StayUpdatedSection() {
             className="
                       min-[768px]:w-[785px] min-[768px]:max-w-[785px] min-[768px]:right-[calc(50%-395px)] min-[768px]:top-[-8px]
                       max-[767.9px]:w-[400px] max-[767.9px]:max-w-[370px] max-[767.9px]:right-[calc(50%-187px)] max-[767.9px]:top-[20px]
-                      absolute ">
+                      absolute pointer-events-none">
             <source src="videos/crosspoints/dotted-path-2.webm" type="video/webm"/>
           </video>
       </div>

--- a/src/pages/StudentsPage.tsx
+++ b/src/pages/StudentsPage.tsx
@@ -40,7 +40,7 @@ const SOCIAL_EVENT_CARDS = [
     image: "/images/student/join-social-blueprint-wide.webp",
     imageClassName: "h-[166.67%] w-[179.49%] -left-[32.67%] -top-[66.67%]",
     accentColor: "#D2A6FB",
-    imageHoverClassName: "md:group-hover/expandable-card:left-[-17.35%] md:group-hover/expandable-card:w-[142.86%]",
+    imageHoverClassName: "lg:group-hover/expandable-card:left-[-17.35%] lg:group-hover/expandable-card:w-[142.86%]",
   },
   {
     title: "Team Socials",
@@ -550,7 +550,7 @@ function OpenPositionsSection() {
   return (
     <section
       id="open-positions"
-      className="mx-auto relative z-10 grid w-full max-w-[1298px] grid-cols-[318px_623px] justify-center gap-[127px] rounded-[20px] bg-bp-black px-[115px] py-[117px] max-lg:flex max-lg:flex-col max-lg:gap-[31px] max-lg:rounded-none max-lg:px-[19px] max-lg:pb-[76px] max-lg:pt-[61px]"
+      className="mx-auto relative z-10 grid w-full max-w-[1298px] grid-cols-[318px_minmax(0,623px)] justify-center gap-[127px] rounded-[20px] bg-bp-black px-[115px] py-[117px] max-xl:gap-[60px] max-xl:px-[60px] max-lg:flex max-lg:flex-col max-lg:gap-[31px] max-lg:rounded-none max-lg:px-[19px] max-lg:pb-[76px] max-lg:pt-[61px]"
     >
       <div className="flex flex-col gap-12 text-white max-lg:gap-0">
         <div className="flex flex-col gap-6">


### PR DESCRIPTION
## What changed 
- Hover interaction function on social cards on For Students page.
  - Updated the Blueprint-Wide Socials, Team Socials, and Career Events cards
  - Changed max-md to max-lg for responsive design to avoid squished view for 3 cards as viewport decreases.
- Fixed children props overflowing in 'Open Positions' in 'For Students Page' 
 
## Screenshots
<img width="1070" height="886" alt="image" src="https://github.com/user-attachments/assets/f7347162-5152-4929-a0ac-348b4ae6e18f" />

<img width="1241" height="508" alt="image" src="https://github.com/user-attachments/assets/2b1bb980-332d-4499-ac9f-9e05bc079d5b" />

### Notes/Suggestions
Should we change tablet view to show more cards? Less white space but scroll bar at the bottom will need a little bit of rework.
<img width="1065" height="849" alt="image" src="https://github.com/user-attachments/assets/a649ade0-d17f-415a-9b51-5339cba9a0a0" />

## Additional Changes
I noticed the content of the open positions was overflowing in the container while testing responsive design. 
<img width="1043" height="673" alt="image" src="https://github.com/user-attachments/assets/1a05aedf-110d-4162-b9a8-1278cac27a92" />

fixed bug:
<img width="1061" height="882" alt="image" src="https://github.com/user-attachments/assets/b6649ff3-7b5b-4559-a69f-fe7857177992" />

## How to test
Hover on 'For Students Page' social cards
Test responsive design on that

Closes #159 