### PR TITLE
Fix: Crosspoints on studentpage no longer overlaps footer.

### DIFF
--- a/src/components/footer/FooterRevamp.tsx
+++ b/src/components/footer/FooterRevamp.tsx
@@ -101,13 +101,13 @@ export default function FooterRevamp() {
   return (
     <footer
       id="app-footer"
-      className="w-full bg-bp-lightest-grey font-poppins"
+      className="w-full relative bg-bp-lightest-grey font-poppins"
     >
       {/* ========================================================== */}
       {/* DESKTOP                                                    */}
       {/* ========================================================== */}
 
-      <div className="hidden w-full px-5 pb-8 pt-footer-py-desktop lg:block">
+      <div className="hidden relative z-10 w-full px-5 pb-8 pt-footer-py-desktop lg:block">
         {/* Same centered boundary as navbar / PageContainer */}
         <div
           className="
@@ -117,6 +117,7 @@ export default function FooterRevamp() {
             px-2
             md:px-6
             xl:px-16
+            z-[11]
           "
         >
           <div
@@ -265,7 +266,7 @@ export default function FooterRevamp() {
       {/* TABLET                                                     */}
       {/* ========================================================== */}
 
-      <div className="hidden w-full px-5 pb-8 pt-footer-py-desktop md:block lg:hidden">
+      <div className="hidden relative z-10 w-full px-5 pb-8 pt-footer-py-desktop md:block lg:hidden">
         <div
           className="
             mx-auto
@@ -412,7 +413,7 @@ export default function FooterRevamp() {
       {/* MOBILE                                                     */}
       {/* ========================================================== */}
 
-      <div className="block w-full px-5 pb-8 pt-footer-py-mobile md:hidden">
+      <div className="block w-full relative px-5 pb-8 pt-footer-py-mobile md:hidden">
         <div
           className="
             mx-auto


### PR DESCRIPTION
## What Changed
- Added the relative style to the different footer formats to prevent a crosspoints video from overlapping on the students page

## Screenshots
### Before:
<img width="878" height="737" alt="Fix-overlap-students" src="https://github.com/user-attachments/assets/c2b48ff5-929b-465b-9f68-c2e3eb6df5d1" />

### After:
<img width="720" height="542" alt="fix-no-overlap-students" src="https://github.com/user-attachments/assets/70a84228-8713-4d4f-b138-5afde16c8212" />

## How to test
run `npm run dev` on the main branch of my repository or view from https://blueprint-website-v2-nine.vercel.app/students
Scroll to the bottom of the page before the footer and verify that there is no overlapping of the footer by the crosspoints image.
- [ ] Desktop
- [ ] Tablet
- [x] Mobile 